### PR TITLE
abstraction over messaging queues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,12 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
-name = "array-init"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30bbe2f5e3d117f55bd8c7a1f9191e4a5deba9f15f595bbea4f670c59c765db"
-
-[[package]]
 name = "array_tool"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +138,17 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
 dependencies = [
- "async-stream-impl",
+ "async-stream-impl 0.2.1",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl 0.3.0",
  "futures-core",
 ]
 
@@ -153,6 +157,17 @@ name = "async-stream-impl"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -499,6 +514,7 @@ dependencies = [
 name = "command-service"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bb8",
  "bb8-postgres",
@@ -520,7 +536,6 @@ dependencies = [
  "url",
  "utils",
  "uuid",
- "warp",
 ]
 
 [[package]]
@@ -719,15 +734,12 @@ dependencies = [
  "env_logger 0.8.1",
  "envy",
  "futures-util",
- "lapin",
  "log",
  "lru-cache",
- "rdkafka",
  "schema-registry",
  "serde",
  "serde_json",
  "tokio 0.2.22",
- "tokio-amqp",
  "utils",
  "uuid",
 ]
@@ -1345,9 +1357,8 @@ dependencies = [
 
 [[package]]
 name = "indradb-lib"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20a863d06a431fbda1fa47289a053111c04f855f70d871c6a7fedf06dec478"
+version = "1.0.3"
+source = "git+https://github.com/jespersm/indradb?branch=sled#c612f8f654341866d3e4147d4ced99a2f6219d3c"
 dependencies = [
  "byteorder",
  "chrono",
@@ -1356,7 +1367,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "serde_json",
- "sled 0.32.1",
+ "sled 0.31.0",
  "uuid",
 ]
 
@@ -2857,7 +2868,6 @@ dependencies = [
  "lazy_static",
  "log",
  "prost",
- "rdkafka",
  "semver 0.11.0",
  "serde",
  "serde_json",
@@ -3082,12 +3092,10 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sled"
-version = "0.32.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3dbbb8ee10611bd1d020767c27599ccbbf8365f7e0ed7e54429cc8b9433ad8"
+checksum = "8fb6824dde66ad33bf20c6e8476f5b82b871bc8bc3c129a10ea2f7dae5060fa3"
 dependencies = [
- "array-init",
- "backtrace",
  "crc32fast",
  "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
@@ -3095,7 +3103,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot 0.11.0",
+ "parking_lot 0.10.2",
 ]
 
 [[package]]
@@ -3590,7 +3598,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
 dependencies = [
- "async-stream",
+ "async-stream 0.2.1",
  "async-trait",
  "base64 0.12.3",
  "bytes 0.5.6",
@@ -3966,14 +3974,24 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream 0.3.0",
+ "async-trait",
+ "futures-util",
  "hyper",
+ "lapin",
  "lazy_static",
  "log",
  "metrics",
  "metrics-exporter-http",
  "metrics-observer-prometheus",
  "metrics-runtime",
+ "rdkafka",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio 0.2.22",
+ "tokio-amqp",
+ "uuid",
 ]
 
 [[package]]

--- a/blob-store/src/main.rs
+++ b/blob-store/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 pub mod args;
 
 use crate::args::Args;

--- a/command-service/Cargo.toml
+++ b/command-service/Cargo.toml
@@ -16,6 +16,7 @@ name = "command_service"
 path = "src/main.rs"
 
 [dependencies]
+anyhow      = "1.0"
 async-trait = "0.1"
 bb8         = "0.4"
 env_logger  = "0.8"
@@ -31,7 +32,6 @@ thiserror   = "1.0"
 tokio       = { version = "0.2", features = ["rt-threaded", "macros", "sync"] }
 tonic       = "0.3"
 utils       = { path = "../utils" }
-warp        = { version = "0.2" }
 url         = "2.1"
 uuid        = { version = "0.8", features = ["v1", "serde"] }
 bb8-postgres            = { version = "0.4", features = ["with-uuid-0_8", "with-serde_json-1"] }

--- a/command-service/src/input/error.rs
+++ b/command-service/src/input/error.rs
@@ -1,17 +1,19 @@
 use std::str::Utf8Error;
 
 use crate::communication;
-use rdkafka::error::KafkaError;
 use thiserror::Error as DeriveError;
+use utils::messaging_system::CommunicationError;
 
 #[derive(Debug, DeriveError)]
 pub enum Error {
+    #[error("Message payload deserialization failed: {0}")]
+    PayloadDeserializationFailed(#[from] serde_json::Error),
     #[error("Failed to create Kafka consumer `{0}`")]
-    ConsumerCreationFailed(KafkaError),
+    ConsumerCreationFailed(CommunicationError),
     #[error("Failed to subscribe to kafka topics `{0}`")]
-    FailedToSubscribe(KafkaError),
-    #[error("Kafka message is missing a key")]
-    MissingKey,
+    FailedToSubscribe(CommunicationError),
+    #[error("Kafka message is missing a key `{0}`")]
+    MissingKey(CommunicationError),
     #[error("Kafka message has a non-UUID key: {0}")]
     KeyNotValidUuid(uuid::Error),
     #[error("Kafka message is missing a schema ID header")]
@@ -20,10 +22,10 @@ pub enum Error {
     InvalidSchemaIdHeader,
     #[error("Unable to parse key as valid UTF8 string `{0}`")]
     UnableToParseUTF8(Utf8Error),
-    #[error("Kafka message is missing payload")]
-    MissingPayload,
+    #[error("Kafka message is missing payload `{0}")]
+    MissingPayload(CommunicationError),
     #[error("Failed to read message `{0}`")]
-    FailedReadingMessage(KafkaError),
+    FailedReadingMessage(CommunicationError),
     #[error("Metric is missing timestamp")]
     TimestampUnavailable,
     #[error("Failed to communicate with handler `{0}`")]

--- a/command-service/src/input/service.rs
+++ b/command-service/src/input/service.rs
@@ -66,7 +66,7 @@ impl KafkaInput {
     }
 
     pub async fn listen(self) -> Result<(), Error> {
-        let consumer = Box::leak(Box::new(self.consumer));
+        let consumer = self.consumer.leak();
         let message_stream = consumer.consume().await;
         pin!(message_stream);
 

--- a/command-service/src/input/service.rs
+++ b/command-service/src/input/service.rs
@@ -1,42 +1,35 @@
-use std::sync::Arc;
-
 use futures_util::stream::StreamExt;
-use log::{error, log_enabled, trace, Level};
-use rdkafka::config::RDKafkaLogLevel;
-use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
-use rdkafka::error::KafkaError;
-use rdkafka::message::{Headers, OwnedMessage};
-use rdkafka::{ClientConfig, Message};
-use uuid::Uuid;
+use log::error;
+use tokio::pin;
 
 use crate::communication::{GenericMessage, MessageRouter};
 use crate::input::{Error, KafkaInputConfig};
-use utils::{metrics::counter, task_limiter::TaskLimiter};
+use utils::{
+    message_types::CommandServiceInsertMessage,
+    messaging_system::{
+        consumer::CommonConsumer, message::CommunicationMessage, CommunicationResult,
+    },
+    metrics::counter,
+    task_limiter::TaskLimiter,
+};
 
 pub struct KafkaInput {
-    consumer: Arc<StreamConsumer<DefaultConsumerContext>>,
+    consumer: CommonConsumer,
     message_router: MessageRouter,
     task_limiter: TaskLimiter,
 }
 
 impl KafkaInput {
-    pub fn new(config: KafkaInputConfig, message_router: MessageRouter) -> Result<Self, Error> {
-        let consumer: StreamConsumer<DefaultConsumerContext> = ClientConfig::default()
-            .set("group.id", &config.group_id)
-            .set("bootstrap.servers", &config.brokers)
-            .set("enable.partition.eof", "false")
-            .set("session.timeout.ms", "6000")
-            .set("enable.auto.commit", "true")
-            .set_log_level(RDKafkaLogLevel::Debug)
-            .create_with_context(DefaultConsumerContext)
-            .map_err(Error::ConsumerCreationFailed)?;
-
-        consumer
-            .subscribe(&[&config.topic])
-            .map_err(Error::FailedToSubscribe)?;
-
+    pub async fn new(
+        config: KafkaInputConfig,
+        message_router: MessageRouter,
+    ) -> Result<Self, Error> {
+        let consumer =
+            CommonConsumer::new_kafka(&config.group_id, &config.brokers, &[&config.topic])
+                .await
+                .map_err(Error::ConsumerCreationFailed)?;
         Ok(Self {
-            consumer: Arc::new(consumer),
+            consumer,
             message_router,
             task_limiter: TaskLimiter::new(config.task_limit),
         })
@@ -44,12 +37,12 @@ impl KafkaInput {
 
     async fn handle_message(
         router: MessageRouter,
-        message: Result<OwnedMessage, KafkaError>,
+        message: CommunicationResult<Box<dyn CommunicationMessage>>,
     ) -> Result<(), Error> {
         counter!("cdl.command-service.input-request", 1);
         let message = message.map_err(Error::FailedReadingMessage)?;
 
-        let generic_message = Self::build_message(&message)?;
+        let generic_message = Self::build_message(message.as_ref())?;
 
         router
             .handle_message(generic_message)
@@ -59,65 +52,26 @@ impl KafkaInput {
         Ok(())
     }
 
-    fn build_message(message: &OwnedMessage) -> Result<GenericMessage, Error> {
-        let key = std::str::from_utf8(message.key().ok_or(Error::MissingKey)?)
-            .map_err(Error::UnableToParseUTF8)?;
-        let object_id = Uuid::parse_str(key).map_err(Error::KeyNotValidUuid)?;
-        let schema_id = Self::get_schema_id(message)?;
-        let payload = message.payload().ok_or(Error::MissingPayload)?.to_vec();
-        let ts = message.timestamp();
+    fn build_message(message: &'_ dyn CommunicationMessage) -> Result<GenericMessage, Error> {
+        let json = message.payload().map_err(Error::MissingPayload)?;
+        let event: CommandServiceInsertMessage =
+            serde_json::from_str(json).map_err(Error::PayloadDeserializationFailed)?;
 
         Ok(GenericMessage {
-            object_id,
-            schema_id,
-            timestamp: ts.to_millis().ok_or(Error::TimestampUnavailable)?,
-            payload,
+            object_id: event.object_id,
+            schema_id: event.schema_id,
+            timestamp: event.timestamp,
+            payload: event.payload.to_string().as_bytes().to_vec(),
         })
     }
 
-    fn get_schema_id(message: &OwnedMessage) -> Result<Uuid, Error> {
-        let schema_id_header = message.headers().and_then(|headers| {
-            for index in 0..headers.count() {
-                let (name, value) = headers.get(index).unwrap();
-                if name == "SCHEMA_ID" {
-                    return Some(value);
-                }
-            }
-
-            None
-        });
-
-        if let Some(header) = schema_id_header {
-            Uuid::parse_str(&String::from_utf8_lossy(header).to_string())
-                .map_err(|_err| Error::InvalidSchemaIdHeader)
-        } else {
-            Err(Error::MissingSchemaIdHeader)
-        }
-    }
-
-    pub async fn listen(&self) -> Result<(), Error> {
-        let mut message_stream = self.consumer.start();
+    pub async fn listen(self) -> Result<(), Error> {
+        let consumer = Box::leak(Box::new(self.consumer));
+        let message_stream = consumer.consume().await;
+        pin!(message_stream);
 
         while let Some(message) = message_stream.next().await {
             let router = self.message_router.clone();
-            let message = message.map(|msg| msg.detach());
-
-            if log_enabled!(Level::Trace) {
-                if let Ok(ref message) = message {
-                    let payload = message.payload().map(String::from_utf8_lossy);
-                    let key = message.key().map(String::from_utf8_lossy);
-                    trace!(
-                        r#"Received Message {{ payload: {:?}, key: {:?}, topic: "{}", timestamp: {:?}, partition: {}, offset: {}, headers: {:?} }}"#,
-                        payload,
-                        key,
-                        message.topic(),
-                        message.timestamp(),
-                        message.partition(),
-                        message.offset(),
-                        message.headers()
-                    );
-                }
-            }
 
             self.task_limiter
                 .run(async move || {

--- a/command-service/src/lib.rs
+++ b/command-service/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(never_type, async_closure, box_syntax)]
+#![feature(async_closure)]
 
 pub mod args;
 pub mod communication;

--- a/command-service/src/output/error.rs
+++ b/command-service/src/output/error.rs
@@ -14,8 +14,6 @@ pub enum OutputError {
     DruidError(druid::Error),
     #[error("Victoria Metrics plugin failed `{0}`")]
     VictoriaMetricsError(victoria_metrics::Error),
-    #[error("Unable to serve metrics API `{0}`")]
-    UnableToServeMetrics(warp::Error),
 }
 
 impl From<sleigh::Error> for OutputError {

--- a/command-service/src/report/error.rs
+++ b/command-service/src/report/error.rs
@@ -1,12 +1,12 @@
-use rdkafka::error::KafkaError;
 use thiserror::Error as DeriveError;
+use utils::messaging_system::CommunicationError;
 
 #[derive(Debug, DeriveError)]
 pub enum Error {
     #[error("Failed to create producer `{0}`")]
-    ProducerCreation(rdkafka::error::KafkaError),
+    ProducerCreation(CommunicationError),
     #[error("Channel was closed on sender side.")]
     SenderDropped,
     #[error("Failed to deliver Kafka report")]
-    FailedToReport(KafkaError),
+    FailedToReport(CommunicationError),
 }

--- a/data-router/Cargo.toml
+++ b/data-router/Cargo.toml
@@ -15,14 +15,11 @@ path = "src/main.rs"
 anyhow      = "1.0"
 env_logger  = "0.8"
 envy        = "0.4"
-lapin       = "1.5"
 log         = "0.4"
 lru-cache   = "0.1"
-rdkafka     = { version = "0.24", features = ["cmake-build"] }
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 tokio       = { version = "0.2", features = ["macros"] }
-tokio-amqp  = "0.1"
 utils       = { path = "../utils" }
 uuid        = { version = "0.8", features = ["v1", "serde"] }
 futures-util            = "0.3"

--- a/data-router/src/main.rs
+++ b/data-router/src/main.rs
@@ -1,28 +1,21 @@
-use std::sync::{Arc, Mutex};
-use std::{process, time::Duration};
-
 use anyhow::Context;
 use futures_util::stream::StreamExt;
-use lapin::{
-    message::Delivery,
-    options::{BasicAckOptions, BasicConsumeOptions},
-    types::FieldTable,
-    Channel, Connection, ConnectionProperties, Consumer,
-};
 use log::error;
 use lru_cache::LruCache;
-use rdkafka::{
-    message::OwnedHeaders,
-    producer::{FutureProducer, FutureRecord},
-    ClientConfig,
-};
-use schema_registry::connect_to_registry;
-use schema_registry::rpc::schema::Id;
+use schema_registry::{connect_to_registry, rpc::schema::Id};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use tokio_amqp::*;
+use std::{
+    process,
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tokio::pin;
 use utils::{
     abort_on_poison,
+    message_types::{CommandServiceInsertMessage, DataRouterInputData},
+    messaging_system::{
+        consumer::CommonConsumer, message::CommunicationMessage, publisher::CommonPublisher,
+    },
     metrics::{self, counter},
 };
 use uuid::Uuid;
@@ -37,115 +30,94 @@ struct Config {
     pub cache_capacity: usize,
 }
 
-#[derive(Deserialize, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InputData {
-    pub schema_id: Uuid,
-    pub object_id: Uuid,
-    pub data: Value,
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let config = Arc::new(envy::from_env::<Config>().context("Env vars not set correctly")?);
-
-    let (_conn, _channel, mut consumer) =
-        create_rabbitmq_consumer(&config.input_addr, &config.input_queue).await?;
-    let producer = Arc::new(build_kafka_producer(&config.kafka_brokers));
-    let cache = Arc::new(Mutex::new(LruCache::new(config.cache_capacity)));
-
-    let message_handler = tokio::spawn(async move {
-        while let Some(delivery) = consumer.next().await {
-            let cache = cache.clone();
-            let producer = producer.clone();
-            let config = config.clone();
-
-            tokio::spawn(async move {
-                let (channel, delivery) = delivery.unwrap();
-
-                let result = handle_input(
-                    &delivery,
-                    &cache,
-                    &config.schema_registry_addr,
-                    producer.clone(),
-                )
-                .await;
-
-                counter!("cdl.data-router.input-request", 1);
-
-                if let Err(error) = result {
-                    error!("{:?}", error);
-                    send_kafka_error(
-                        producer,
-                        config.kafka_error_channel.clone(),
-                        format!("{:?}", error),
-                    );
-                }
-                let ack_result = channel
-                    .basic_ack(delivery.delivery_tag, BasicAckOptions::default())
-                    .await;
-                if let Err(e) = ack_result {
-                    error!(
-                        "Fatal error, delivery status for message not received. {:?}",
-                        e
-                    );
-                    process::abort();
-                }
-            });
-        }
-    });
-
     metrics::serve();
-    message_handler.await?;
 
+    let consumer =
+        CommonConsumer::new_rabbit(&config.input_addr, "CDL_DATA_ROUTER", &config.input_queue)
+            .await?;
+    let producer = Arc::new(
+        CommonPublisher::new_kafka(&config.kafka_brokers)
+            .await
+            .unwrap(),
+    );
+    let cache = Arc::new(Mutex::new(LruCache::new(config.cache_capacity)));
+    let consumer = Box::leak(Box::new(consumer));
+    let message_stream = consumer.consume().await;
+    pin!(message_stream);
+    while let Some(message) = message_stream.next().await {
+        match message {
+            Ok(message) => {
+                tokio::spawn(handle_message(
+                    message,
+                    cache.clone(),
+                    producer.clone(),
+                    config.clone(),
+                ));
+            }
+            Err(error) => {
+                error!("Error fetching data from message queue {:?}", error);
+                // no error handling necessary - message won't be acked - it was never delivered properly
+            }
+        };
+    }
     Ok(())
 }
-async fn create_rabbitmq_consumer(
-    addr: &str,
-    queue_name: &str,
-) -> anyhow::Result<(Connection, Channel, Consumer)> {
-    let conn = Connection::connect(addr, ConnectionProperties::default().with_tokio()).await?;
-    let channel = conn.create_channel().await?;
 
-    // channel
-    //     .queue_declare(
-    //         queue_name,
-    //         QueueDeclareOptions::default(),
-    //         FieldTable::default(),
-    //     )
-    //     .await?;
+async fn handle_message(
+    message: Box<dyn CommunicationMessage>,
+    cache: Arc<Mutex<LruCache<Uuid, String>>>,
+    producer: Arc<CommonPublisher>,
+    config: Arc<Config>,
+) {
+    let result: anyhow::Result<()> = async {
+        let event: DataRouterInputData =
+            serde_json::from_str(message.payload()?).context("Payload deserialization failed")?;
+        let since_the_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards"); // TODO: Ordering can be different when scaling
+        let topic_name = get_schema_topic(&cache, &event, &config.schema_registry_addr).await?;
+        let data = CommandServiceInsertMessage {
+            object_id: event.object_id,
+            payload: event.data,
+            schema_id: event.schema_id,
+            timestamp: since_the_epoch.as_millis() as i64, // TODO: Change types?
+        };
+        let payload = serde_json::to_vec(&data).unwrap_or_default();
+        let key = data.object_id.to_string();
+        send_message(producer.as_ref(), &topic_name, &key, payload).await;
+        Ok(())
+    }
+    .await;
 
-    let consumer = channel
-        .basic_consume(
-            queue_name,
-            "CDL_DATA_ROUTER",
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
+    counter!("cdl.data-router.input-request", 1);
+
+    if let Err(error) = result {
+        error!("{:?}", error);
+        send_message(
+            producer.as_ref(),
+            &config.kafka_error_channel,
+            &"data-router",
+            format!("{:?}", error).into(),
         )
-        .await?;
-
-    Ok((conn, channel, consumer))
-}
-
-async fn handle_input(
-    delivery: &Delivery,
-    cache: &Mutex<LruCache<Uuid, String>>,
-    schema_addr: &str,
-    producer: Arc<FutureProducer>,
-) -> anyhow::Result<()> {
-    let json = std::str::from_utf8(&delivery.data).context("Payload was not valid UTF-8")?;
-    let event: InputData = serde_json::from_str(json).context("Payload deserialization failed")?;
-
-    let topic_name = get_schema_topic(cache, &event, schema_addr).await?;
-
-    send_messages_to_kafka(producer, topic_name, event);
-    Ok(())
+        .await;
+    }
+    let ack_result = message.ack().await;
+    if let Err(e) = ack_result {
+        error!(
+            "Fatal error, delivery status for message not received. {:?}",
+            e
+        );
+        process::abort();
+    }
 }
 
 async fn get_schema_topic(
     cache: &Mutex<LruCache<Uuid, String>>,
-    event: &InputData,
+    event: &DataRouterInputData<'_>,
     schema_addr: &str,
 ) -> anyhow::Result<String> {
     let recv_channel = cache
@@ -173,48 +145,14 @@ async fn get_schema_topic(
     Ok(channel)
 }
 
-fn send_messages_to_kafka(producer: Arc<FutureProducer>, topic_name: String, value: InputData) {
-    tokio::spawn(async move {
-        let key = &value.object_id.to_string();
-        let payload = &serde_json::to_vec(&value.data).unwrap_or_default();
-        let delivery_status = producer.send(
-            FutureRecord::to(&topic_name)
-                .payload(payload)
-                .headers(OwnedHeaders::new().add("SCHEMA_ID", &value.schema_id.to_string()))
-                .key(key),
-            Duration::from_secs(1),
+async fn send_message(producer: &CommonPublisher, topic_name: &str, key: &str, payload: Vec<u8>) {
+    let delivery_status = producer.publish_message(&topic_name, key, payload).await;
+
+    if delivery_status.is_err() {
+        error!(
+            "Fatal error, delivery status for message not received. {:?}",
+            delivery_status
         );
-
-        if delivery_status.await.is_err() {
-            error!("Fatal error, delivery status for message not received.");
-            process::abort();
-        };
-    });
-}
-
-fn build_kafka_producer(brokers: &str) -> FutureProducer {
-    // https://kafka.apache.org/documentation/#producerconfigs
-    // TODO: should connect to kafka and check if connection was successful before reporting service as started
-    //       (otherwise there is no way of knowing that kafka broker is unreachable)
-    ClientConfig::new()
-        .set("bootstrap.servers", &brokers)
-        .set("message.timeout.ms", "5000")
-        .set("acks", "all")
-        .set("compression.type", "none")
-        .set("max.in.flight.requests.per.connection", "1")
-        .create()
-        .expect("Producer creation error")
-}
-
-fn send_kafka_error(producer: Arc<FutureProducer>, topic_name: String, value: String) {
-    tokio::spawn(async move {
-        let delivery_status = producer.send(
-            FutureRecord::to(&topic_name).payload(&value).key("error"),
-            Duration::from_secs(1),
-        );
-        if delivery_status.await.is_err() {
-            error!("Fatal error, delivery status for message not received.");
-            process::abort();
-        };
-    });
+        process::abort();
+    };
 }

--- a/document-storage/src/lib.rs
+++ b/document-storage/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(never_type, box_syntax)]
-
 pub mod grpc;
 
 pub const GRPC_PORT: u16 = 58102;

--- a/document-storage/src/main.rs
+++ b/document-storage/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 pub mod args;
 
 use crate::args::Args;

--- a/helm/cdl/templates/template.yml
+++ b/helm/cdl/templates/template.yml
@@ -146,7 +146,7 @@ spec:
         - name: KAFKA_GROUP_ID
           value: "data-router"
         - name: KAFKA_ERROR_CHANNEL
-          value: {{ .Values.reportTopic }}
+          value: {{ .Values.global.reportTopic }}
         - name: SCHEMA_REGISTRY_ADDR
           value: "http://{{ .Release.Name }}-schema-registry:6400"
         - name: CACHE_CAPACITY

--- a/query-service/src/lib.rs
+++ b/query-service/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 use error::ClientError;
 use schema::{query_client::QueryClient, ObjectIds, SchemaId};
 use std::collections::HashMap;

--- a/schema-registry/Cargo.toml
+++ b/schema-registry/Cargo.toml
@@ -23,7 +23,6 @@ envy        = "0.4"
 futures     = "0.3"
 log         = "0.4"
 prost       = "0.6"
-rdkafka     = { version = "0.24", features = ["cmake-build"] }
 indradb-lib = { git = "https://github.com/jespersm/indradb", branch = "sled", features = ["sled-datastore"] } # We use fork due to reported incompatibility of sled 0.34 with azure k8s. More testing needed before switching to official build.
 jmespatch   = "0.3"
 jsonschema  = "0.3"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,11 +13,21 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow      = "1.0"
+async-trait = "0.1"
 hyper       = "0.13"
+lapin       = "1.4"
 lazy_static = "1.4"
 log         = "0.4"
 metrics     = { version = "0.12", features = ["std"] }
+rdkafka     = { version = "0.24", features = ["cmake-build"] }
+serde       = { version = "1.0", features = ["derive"] }
+serde_json  = { version = "1.0", features = ["raw_value"] }
+thiserror   = "1.0"
 tokio       = { version = "0.2", features = ["rt-core"] }
+tokio-amqp  = "0.1"
+uuid        = { version = "0.8", features = ["v1", "serde"] }
+async-stream            = "0.3"
+futures-util            = "0.3"
 metrics-exporter-http   = "0.3"
 metrics-runtime         = "0.13"
 metrics-observer-prometheus         = "0.1"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,6 +1,8 @@
 use log::error;
 use std::{process, sync::PoisonError};
 
+pub mod message_types;
+pub mod messaging_system;
 pub mod metrics;
 pub mod status_endpoints;
 pub mod task_limiter;

--- a/utils/src/message_types.rs
+++ b/utils/src/message_types.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CommandServiceInsertMessage<'a> {
+    pub object_id: Uuid,
+    pub schema_id: Uuid,
+    pub timestamp: i64,
+    #[serde(borrow)]
+    pub payload: &'a RawValue,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataRouterInputData<'a> {
+    pub schema_id: Uuid,
+    pub object_id: Uuid,
+    #[serde(borrow)]
+    pub data: &'a RawValue,
+}

--- a/utils/src/messaging_system/consumer.rs
+++ b/utils/src/messaging_system/consumer.rs
@@ -1,0 +1,102 @@
+use anyhow::Context;
+use async_stream::try_stream;
+use futures_util::stream::{Stream, StreamExt};
+use lapin::{options::BasicConsumeOptions, types::FieldTable, Channel, Connection};
+use rdkafka::{
+    consumer::{DefaultConsumerContext, StreamConsumer},
+    ClientConfig,
+};
+use std::sync::Arc;
+use tokio_amqp::LapinTokioExt;
+
+use super::{
+    message::CommunicationMessage, message::KafkaCommunicationMessage,
+    message::RabbitCommunicationMessage, CommunicationResult,
+};
+
+pub enum CommonConsumer {
+    Kafka {
+        consumer: Arc<StreamConsumer<DefaultConsumerContext>>,
+    },
+    RabbitMq {
+        _connection: Box<Connection>,
+        _channel: Box<Channel>,
+        consumer: lapin::Consumer,
+    },
+}
+impl CommonConsumer {
+    pub async fn new_kafka(
+        group_id: &str,
+        brokers: &str,
+        topics: &[&str],
+    ) -> CommunicationResult<CommonConsumer> {
+        let consumer: StreamConsumer<DefaultConsumerContext> = ClientConfig::new()
+            .set("group.id", &group_id)
+            .set("bootstrap.servers", &brokers)
+            .set("enable.partition.eof", "false")
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "true")
+            .set("auto.offset.reset", "earliest")
+            .create()
+            .context("Consumer creation failed")?;
+
+        rdkafka::consumer::Consumer::subscribe(&consumer, topics)
+            .context("Can't subscribe to specified topics")?;
+
+        Ok(CommonConsumer::Kafka {
+            consumer: Arc::new(consumer),
+        })
+    }
+
+    pub async fn new_rabbit(
+        connection_string: &str,
+        consumer_tag: &str,
+        queue_name: &str,
+    ) -> CommunicationResult<CommonConsumer> {
+        let connection = lapin::Connection::connect(
+            connection_string,
+            lapin::ConnectionProperties::default().with_tokio(),
+        )
+        .await?;
+        let channel = connection.create_channel().await?;
+        let consumer = channel
+            .basic_consume(
+                queue_name,
+                consumer_tag,
+                BasicConsumeOptions::default(),
+                FieldTable::default(),
+            )
+            .await?;
+        Ok(CommonConsumer::RabbitMq {
+            _channel: Box::new(channel),
+            _connection: Box::new(connection),
+            consumer,
+        })
+    }
+
+    pub async fn consume(
+        &mut self,
+    ) -> impl Stream<Item = CommunicationResult<Box<dyn CommunicationMessage + '_>>> {
+        try_stream! {
+        match self {
+            CommonConsumer::Kafka { consumer } => {
+                let mut message_stream = consumer.start();
+                    while let Some(message) = message_stream.next().await {
+                        let message = message?;
+                        yield Box::new(KafkaCommunicationMessage{message,consumer:consumer.clone()}) as Box<dyn CommunicationMessage>;
+                    }
+                }
+                CommonConsumer::RabbitMq {
+                    consumer,
+                    _connection,
+                    _channel,
+                } => {
+                    while let Some(message) = consumer.next().await {
+                        let message = message?;
+                        yield Box::new(RabbitCommunicationMessage{channel:message.0, delivery:message.1})as Box<dyn CommunicationMessage>;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/utils/src/messaging_system/message.rs
+++ b/utils/src/messaging_system/message.rs
@@ -1,0 +1,69 @@
+use anyhow::Context;
+use async_trait::async_trait;
+use lapin::{message::Delivery, options::BasicAckOptions, Channel};
+use rdkafka::{
+    consumer::CommitMode,
+    consumer::{DefaultConsumerContext, StreamConsumer},
+    message::BorrowedMessage,
+    Message,
+};
+use std::sync::Arc;
+
+use super::CommunicationResult;
+
+#[async_trait]
+pub trait CommunicationMessage: Send + Sync {
+    fn payload(&self) -> CommunicationResult<&str>;
+    fn key(&self) -> CommunicationResult<&str>;
+    async fn ack(&self) -> CommunicationResult<()>;
+}
+
+pub struct KafkaCommunicationMessage<'a> {
+    pub(super) message: BorrowedMessage<'a>,
+    pub(super) consumer: Arc<StreamConsumer<DefaultConsumerContext>>,
+}
+#[async_trait]
+impl<'a> CommunicationMessage for KafkaCommunicationMessage<'a> {
+    fn key(&self) -> CommunicationResult<&str> {
+        let key = self
+            .message
+            .key()
+            .ok_or_else(|| anyhow::anyhow!("Message has no key"))?;
+        Ok(std::str::from_utf8(key)?)
+    }
+    fn payload(&self) -> CommunicationResult<&str> {
+        Ok(self
+            .message
+            .payload_view::<str>()
+            .ok_or_else(|| anyhow::anyhow!("Message has no payload"))??)
+    }
+    async fn ack(&self) -> CommunicationResult<()> {
+        rdkafka::consumer::Consumer::commit_message(
+            self.consumer.as_ref(),
+            &self.message,
+            CommitMode::Async,
+        )?;
+        Ok(())
+    }
+}
+
+pub struct RabbitCommunicationMessage {
+    pub(super) channel: Channel,
+    pub(super) delivery: Delivery,
+}
+#[async_trait]
+impl CommunicationMessage for RabbitCommunicationMessage {
+    fn key(&self) -> CommunicationResult<&str> {
+        let key = self.delivery.routing_key.as_str();
+        Ok(key)
+    }
+    fn payload(&self) -> CommunicationResult<&str> {
+        Ok(std::str::from_utf8(&self.delivery.data).context("Payload was not valid UTF-8")?)
+    }
+    async fn ack(&self) -> CommunicationResult<()> {
+        Ok(self
+            .channel
+            .basic_ack(self.delivery.delivery_tag, BasicAckOptions::default())
+            .await?)
+    }
+}

--- a/utils/src/messaging_system/mod.rs
+++ b/utils/src/messaging_system/mod.rs
@@ -1,0 +1,34 @@
+use thiserror::Error;
+
+pub mod consumer;
+pub mod message;
+pub mod publisher;
+
+#[derive(Debug, Error)]
+pub enum CommunicationError {
+    #[error("Error during communication via message queue \"{0}\"")]
+    InternalError(String),
+}
+
+pub type CommunicationResult<T> = Result<T, CommunicationError>;
+
+impl From<rdkafka::error::KafkaError> for CommunicationError {
+    fn from(error: rdkafka::error::KafkaError) -> CommunicationError {
+        CommunicationError::InternalError(error.to_string())
+    }
+}
+impl From<anyhow::Error> for CommunicationError {
+    fn from(error: anyhow::Error) -> CommunicationError {
+        CommunicationError::InternalError(error.to_string())
+    }
+}
+impl From<lapin::Error> for CommunicationError {
+    fn from(error: lapin::Error) -> CommunicationError {
+        CommunicationError::InternalError(error.to_string())
+    }
+}
+impl From<std::str::Utf8Error> for CommunicationError {
+    fn from(error: std::str::Utf8Error) -> CommunicationError {
+        CommunicationError::InternalError(error.to_string())
+    }
+}

--- a/utils/src/messaging_system/publisher.rs
+++ b/utils/src/messaging_system/publisher.rs
@@ -1,0 +1,83 @@
+use lapin::{options::BasicPublishOptions, BasicProperties, Channel, Connection};
+use rdkafka::{
+    producer::{FutureProducer, FutureRecord},
+    ClientConfig,
+};
+use std::time::Duration;
+use tokio_amqp::LapinTokioExt;
+
+use super::CommunicationResult;
+
+pub enum CommonPublisher {
+    Kafka {
+        producer: FutureProducer,
+    },
+    RabbitMq {
+        _connection: Box<Connection>,
+        channel: Channel,
+    },
+}
+impl CommonPublisher {
+    pub async fn new_rabbit(connection_string: &str) -> CommunicationResult<CommonPublisher> {
+        let connection = lapin::Connection::connect(
+            connection_string,
+            lapin::ConnectionProperties::default().with_tokio(),
+        )
+        .await?;
+        let channel = connection.create_channel().await?;
+
+        Ok(CommonPublisher::RabbitMq {
+            _connection: Box::new(connection),
+            channel,
+        })
+    }
+
+    pub async fn new_kafka(brokers: &str) -> CommunicationResult<CommonPublisher> {
+        let publisher = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("message.timeout.ms", "5000")
+            .set("acks", "all")
+            .set("compression.type", "none")
+            .set("max.in.flight.requests.per.connection", "1")
+            .create()?;
+        Ok(CommonPublisher::Kafka {
+            producer: publisher,
+        })
+    }
+
+    pub async fn publish_message(
+        &self,
+        topic_or_exchange: &str,
+        key: &str,
+        payload: Vec<u8>,
+    ) -> CommunicationResult<()> {
+        match self {
+            CommonPublisher::Kafka { producer } => {
+                let delivery_status = producer.send(
+                    FutureRecord::to(topic_or_exchange)
+                        .payload(&payload)
+                        .key(key),
+                    Duration::from_secs(5),
+                );
+                delivery_status.await.map_err(|x| x.0)?;
+                Ok(())
+            }
+            CommonPublisher::RabbitMq {
+                _connection,
+                channel,
+            } => {
+                channel
+                    .basic_publish(
+                        topic_or_exchange,
+                        key,
+                        BasicPublishOptions::default(),
+                        payload,
+                        BasicProperties::default(),
+                    )
+                    .await?
+                    .await?;
+                Ok(())
+            }
+        }
+    }
+}


### PR DESCRIPTION
- abstraction over communication method
   - allows easy change from kafka to rabbit and vice versa - only consumer/publisher initialization is message system specific
   - doesn't support runtime/compile flag selection of which messaging system we want to use
- some code cleanup(e.g. unused feature flags, unused code)

TODO(outside of this PR scope):
- a way to change messaging system without making code changes - feature flags, runtime check or something else
- there might be some obsolete method/variable names

I'm not exactly sure how to handle errors here. Currently I'm converting each error to common error type - alternatively we can use same approach as in command service(different error type for each error) or deal with that some other way.