### PR TITLE
[FIX] 'cld' -> 'cdl'

### DIFF
--- a/helm/cdl/values-local.yaml
+++ b/helm/cdl/values-local.yaml
@@ -27,7 +27,7 @@ leaderElector:
 
 
 commandService:
-  image: cld-command-service
+  image: cdl-command-service
   bin: command-service
 
 documentStorage:
@@ -40,7 +40,7 @@ postgres-document:
   postgresConnectionString: "postgres://postgres:CHANGEME@infrastructure-postgresql/CDL"
   inputTopic: cdl.document.data
   commandService:
-    image: cld-command-service
+    image: cdl-command-service
     bin: command-service
 
 sled-document:
@@ -56,7 +56,7 @@ sled-document:
     image: cdl-data-router
     bin: data-router
   commandService:
-    image: cld-command-service
+    image: cdl-command-service
     bin: command-service
 
 druid-timeseries:
@@ -64,5 +64,5 @@ druid-timeseries:
   inputTopic: cdl.timeseries.data
   outputTopic: cdl.timeseries.generic-druid
   commandService:
-    image: cld-command-service
+    image: cdl-command-service
     bin: command-service

--- a/helm/cdl/values.yaml
+++ b/helm/cdl/values.yaml
@@ -25,7 +25,7 @@ leaderElector:
   bin: leader-elector
 
 commandService:
-  image: cld-command-service
+  image: cdl-command-service
   bin: command-service
 
 documentStorage:
@@ -38,7 +38,7 @@ postgres-document:
   postgresConnectionString: "postgres://postgres:postgres@10.1.1.5/cdldb"
   inputTopic: cdl.document.data
   commandService:
-    image: cld-command-service
+    image: cdl-command-service
     bin: command-service
 
 sled-document:
@@ -54,7 +54,7 @@ sled-document:
     image: cdl-data-router
     bin: data-router
   commandService:
-    image: cld-command-service
+    image: cdl-command-service
     bin: command-service
 
 druid-timeseries:
@@ -62,5 +62,5 @@ druid-timeseries:
   inputTopic: cdl.timeseries.data
   outputTopic: cdl.timeseries.generic-druid
   commandService:
-    image: cld-command-service
+    image: cdl-command-service
     bin: command-service


### PR DESCRIPTION
This time deployed to azure to check if works:
```
❯ env KUBECONFIG=kubeconfig kubectl -n cdl get all
NAME                                                READY   STATUS             RESTARTS   AGE
pod/cdl-data-router-55fc4cbd99-mkjg2                0/1     CrashLoopBackOff   7          14m
pod/cdl-druid-command-service-6c6d66cffb-sj4ww      1/1     Running            0          14m
pod/cdl-leader-elector-6bb47f5c88-86v5n             1/1     Running            0          14m
pod/cdl-postgres-command-service-5c587d4cdb-5brv9   1/1     Running            0          14m
pod/cdl-schema-registry-0                           0/1     Pending            0          14m

NAME                                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
service/cdl-schema-registry          ClusterIP   10.96.60.161   <none>        6400/TCP         14m
service/cdl-schema-registry-master   NodePort    10.96.75.131   <none>        6400:30150/TCP   14m
service/cdl-sled-db                  ClusterIP   10.96.207.43   <none>        58102/TCP        14m

NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cdl-data-router                0/1     1            0           14m
deployment.apps/cdl-druid-command-service      1/1     1            1           14m
deployment.apps/cdl-leader-elector             1/1     1            1           14m
deployment.apps/cdl-postgres-command-service   1/1     1            1           14m
deployment.apps/cdl-sled-command-service       0/0     0            0           14m

NAME                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/cdl-data-router-55fc4cbd99                1         1         0       14m
replicaset.apps/cdl-druid-command-service-6c6d66cffb      1         1         1       14m
replicaset.apps/cdl-leader-elector-6bb47f5c88             1         1         1       14m
replicaset.apps/cdl-postgres-command-service-5c587d4cdb   1         1         1       14m
replicaset.apps/cdl-sled-command-service-f874545c9        0         0         0       14m

NAME                                   READY   AGE
statefulset.apps/cdl-schema-registry   0/1     14m
statefulset.apps/cdl-sled-db           0/0     14m
```
Notes:
* Data router fails cause I didn't provide proper credentials for rabbitmq & postgres
* Schema registry is pending cause bare epiphany has no Persistent Storage (maybe im wrong? I need to check that).