### PR TITLE
fix(command-service): Add more details to error

### DIFF
--- a/command-service/src/report/error.rs
+++ b/command-service/src/report/error.rs
@@ -5,7 +5,7 @@ use utils::messaging_system::CommunicationError;
 pub enum Error {
     #[error("Failed to create producer `{0}`")]
     ProducerCreation(CommunicationError),
-    #[error("Failed to deliver Kafka report")]
+    #[error("Failed to deliver Kafka report `{0}`")]
     FailedToReport(CommunicationError),
     #[error("Failed to produce error message `{0}`")]
     FailedToProduceErrorMessage(serde_json::Error),


### PR DESCRIPTION
We need more details why command-service-postgres fails. For example missing queue for status.