### PR TITLE
fix(command-service): Use format with strong schema validation.

### DIFF
--- a/command-service/src/output/psql/error.rs
+++ b/command-service/src/output/psql/error.rs
@@ -8,4 +8,8 @@ pub enum Error {
     RecvDropped,
     #[error("Failed to parse url into postgres connection string `{0}`")]
     FailedToParseUrl(bb8_postgres::tokio_postgres::Error),
+    #[error(
+        "Schema `{0}` has invalid name. It can contain only ascii letters, numbers and underscores"
+    )]
+    InvalidSchemaName(String),
 }


### PR DESCRIPTION
Unfortunately psql doesn't support `$1` parameter in schema name position because then it cannot validate table columns if these are correct.