### PR TITLE
feat(query-router): route requests based on schema type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,6 +2472,7 @@ dependencies = [
  "query-service",
  "query-service-ts",
  "schema-registry",
+ "serde",
  "serde_json",
  "structopt",
  "tokio 0.2.23",

--- a/query-router/Cargo.toml
+++ b/query-router/Cargo.toml
@@ -17,6 +17,7 @@ env_logger  = "0.8"
 warp        = "0.2"
 anyhow      = "1.0"
 lru-cache   = "0.1"
+serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 structopt   = "0.3"
 utils       = { path = "../utils/" }

--- a/query-router/README.md
+++ b/query-router/README.md
@@ -3,7 +3,7 @@
 The REST interface over the CDL, used for retrieving data from any repository.
 
 ## Running
-To run the **query-router** requires the [Schema Registry][schema-registry] to be running and the [Query Services][query-service] connected to their respective repositories.
+To run the **query-router** requires the [Schema Registry][schema-registry] to be running and the [Query Services][query-service] or the [Timeseries Query Services][query-service-ts] connected to their respective repositories.
 
 Configuration is expected through the following environment variables:
 
@@ -18,12 +18,16 @@ _Note: Currently, the cache is valid forever: changing a schema's **query-servic
 ## Functionality
 REST API specification is available in [OpenAPI 3.0 spec][api-spec].
 
-Currently, the **query-router** can handle querying data by ID from document repositories.
+Currently, the **query-router** can:
+- handle querying data by ID from document repositories,
+- query range of data by ID from time series repositories,
+- query data from repositories by SCHEMA_ID.
 
-Rough sketch of working process:  
+Rough sketch of working process:
 ![../docs/graphs/QueryRouter-DataRetrieval.puml][query-router-puml]
 
 [query-router-puml]: http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/epiphany-platform/CommonDataLayer/develop/docs/graphs/query_router_data_retrieval.puml
 [schema-registry]: ../schema-registry/README.md
 [query-service]: ../query-service
+[query-service-ts]: ../query-service-ts
 [api-spec]: ./api.yml

--- a/query-router/api.yml
+++ b/query-router/api.yml
@@ -4,7 +4,7 @@ info:
   version: 0.1.0
 paths:
   /single/{object_id}:
-    get:
+    post:
       summary: Retrieve single object
       operationId: getSingleObject
       parameters:

--- a/query-router/api.yml
+++ b/query-router/api.yml
@@ -22,6 +22,14 @@ paths:
           schema:
             type: string
             example: "15251181-f749-42e0-b4a4-e4b3d90e990d"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Empty'
+                - $ref: '#/components/schemas/Range'
       responses:
         '200':
           description: >-
@@ -85,3 +93,17 @@ paths:
             application/json:
               schema:
                 type: object
+
+components:
+  schemas:
+    Empty:
+      type: object
+    Range:
+      type: object
+      properties:
+        from:
+          type: string
+        to:
+          type: string
+        step:
+          type: string

--- a/query-router/api.yml
+++ b/query-router/api.yml
@@ -45,6 +45,8 @@ paths:
           example: "bcebabfe-8da6-4c37-aa97-b373db2f2338,2454b325-9cdb-48e1-bc97-02720d689951"
           schema:
             type: array
+            items:
+              type: string
         - name: SCHEMA_ID
           in: header
           description: 'Schema ID of document to retrieve'

--- a/query-router/src/cache.rs
+++ b/query-router/src/cache.rs
@@ -5,31 +5,32 @@ use std::sync::{Mutex, MutexGuard};
 use utils::abort_on_poison;
 use uuid::Uuid;
 
-pub struct AddressCache {
+pub struct SchemaRegistryCache {
     schema_registry_addr: String,
-    addresses: Mutex<LruCache<Uuid, String>>,
+    cache: Mutex<LruCache<Uuid, (String, SchemaType)>>,
 }
 
-impl AddressCache {
+impl SchemaRegistryCache {
     pub fn new(schema_registry_addr: String, capacity: usize) -> Self {
         Self {
             schema_registry_addr,
-            addresses: Mutex::new(LruCache::new(capacity)),
+            cache: Mutex::new(LruCache::new(capacity)),
         }
     }
 
-    fn lock(&self) -> MutexGuard<LruCache<Uuid, String>> {
-        self.addresses.lock().unwrap_or_else(abort_on_poison)
+    fn lock(&self) -> MutexGuard<LruCache<Uuid, (String, SchemaType)>> {
+        self.cache.lock().unwrap_or_else(abort_on_poison)
     }
 
-    pub async fn get_address(&self, schema_id: Uuid) -> Result<String, Error> {
-        if let Some(address) = self.lock().get_mut(&schema_id) {
-            return Ok(address.clone());
+    pub async fn get_schema_info(&self, schema_id: Uuid) -> Result<(String, SchemaType), Error> {
+        if let Some(cached_data) = self.lock().get_mut(&schema_id) {
+            return Ok(cached_data.clone());
         }
 
         let mut conn = schema_registry::connect_to_registry(self.schema_registry_addr.clone())
             .await
             .map_err(Error::RegistryConnectionError)?;
+
         let response = conn
             .get_schema_query_address(schema_registry::rpc::schema::Id {
                 id: schema_id.to_string(),
@@ -38,47 +39,17 @@ impl AddressCache {
             .map_err(Error::RegistryError)?;
         let address = response.into_inner().address;
 
-        self.lock().insert(schema_id, address.clone());
-
-        Ok(address)
-    }
-}
-
-pub struct SchemaTypeCache {
-    schema_registry_addr: String,
-    schema_types: Mutex<LruCache<Uuid, SchemaType>>,
-}
-
-impl SchemaTypeCache {
-    pub fn new(schema_registry_addr: String, capacity: usize) -> Self {
-        Self {
-            schema_registry_addr,
-            schema_types: Mutex::new(LruCache::new(capacity)),
-        }
-    }
-
-    fn lock(&self) -> MutexGuard<LruCache<Uuid, SchemaType>> {
-        self.schema_types.lock().unwrap_or_else(abort_on_poison)
-    }
-
-    pub async fn get_schema_type(&self, schema_id: Uuid) -> Result<SchemaType, Error> {
-        if let Some(schema_type) = self.lock().get_mut(&schema_id) {
-            return Ok(schema_type.clone());
-        }
-
-        let mut conn = schema_registry::connect_to_registry(self.schema_registry_addr.clone())
-            .await
-            .map_err(Error::RegistryConnectionError)?;
         let response = conn
             .get_schema_type(schema_registry::rpc::schema::Id {
                 id: schema_id.to_string(),
             })
             .await
             .map_err(Error::RegistryError)?;
-        let schema_type = response.into_inner().schema_type();
+        let schema_type = response.into_inner().schema_type().into();
 
-        self.lock().insert(schema_id, schema_type.into());
+        let result = (address, schema_type);
+        self.lock().insert(schema_id, result.clone());
 
-        Ok(schema_type.into())
+        Ok(result)
     }
 }

--- a/query-router/src/handler.rs
+++ b/query-router/src/handler.rs
@@ -1,25 +1,62 @@
-use crate::{cache::AddressCache, error::Error};
+use crate::{
+    cache::{AddressCache, SchemaTypeCache},
+    error::Error,
+};
 use log::trace;
+use schema_registry::types::SchemaType;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Body {
+    Range {
+        from: String,
+        to: String,
+        step: String,
+    },
+    Empty {},
+}
+
 pub async fn query_single(
     object_id: Uuid,
     schema_id: Uuid,
-    cache: Arc<AddressCache>,
+    address_cache: Arc<AddressCache>,
+    schema_type_cache: Arc<SchemaTypeCache>,
+    request_body: Body,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     trace!("Received /single/{} (SCHEMA_ID={})", object_id, schema_id);
 
-    let address = cache.get_address(schema_id).await?;
-    let mut values = query_service::query_multiple(vec![object_id.to_string()], address)
-        .await
-        .map_err(Error::QueryError)?;
+    let address = address_cache.get_address(schema_id).await?;
+    let schema_type = schema_type_cache.get_schema_type(schema_id).await?;
+
+    let values = match (schema_type, request_body) {
+        (SchemaType::DocumentStorage, _) => {
+            let mut values = query_service::query_multiple(vec![object_id.to_string()], address)
+                .await
+                .map_err(Error::QueryError)?;
+
+            values
+                .remove(&object_id.to_string())
+                .ok_or(Error::SingleQueryMissingValue)
+        }
+
+        (SchemaType::Timeseries, Body::Range { from, to, step }) => {
+            let timeseries =
+                query_service_ts::query_by_range(object_id.to_string(), from, to, step, address)
+                    .await
+                    .map_err(Error::QueryError)?;
+
+            Ok(timeseries.as_bytes().to_vec())
+        }
+
+        (SchemaType::Timeseries, Body::Empty {}) => Err(Error::SingleQueryMissingValue),
+    }?;
 
     Ok(warp::reply::with_header(
-        values
-            .remove(&object_id.to_string())
-            .ok_or(Error::SingleQueryMissingValue)?,
+        values,
         "Content-Type",
         "application/json",
     ))
@@ -28,7 +65,7 @@ pub async fn query_single(
 pub async fn query_multiple(
     object_ids: String,
     schema_id: Uuid,
-    cache: Arc<AddressCache>,
+    address_cache: Arc<AddressCache>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     trace!(
         "Received /multiple/{:?} (SCHEMA_ID={})",
@@ -36,7 +73,7 @@ pub async fn query_multiple(
         schema_id
     );
 
-    let address = cache.get_address(schema_id).await?;
+    let address = address_cache.get_address(schema_id).await?;
     let object_ids = object_ids.split(',').map(str::to_owned).collect();
     let values = query_service::query_multiple(object_ids, address)
         .await
@@ -47,16 +84,30 @@ pub async fn query_multiple(
 
 pub async fn query_by_schema(
     schema_id: Uuid,
-    cache: Arc<AddressCache>,
+    address_cache: Arc<AddressCache>,
+    schema_type_cache: Arc<SchemaTypeCache>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     trace!("Received /schema (SCHEMA_ID={})", schema_id);
 
-    let address = cache.get_address(schema_id).await?;
-    let values = query_service::query_by_schema(schema_id.to_string(), address)
-        .await
-        .map_err(Error::QueryError)?;
-    // TODO: switch between correct QS, this is being worked on by Issue #18
-    Ok(warp::reply::json(&byte_map_to_json_map(values)?))
+    let address = address_cache.get_address(schema_id).await?;
+
+    let schema_type = schema_type_cache.get_schema_type(schema_id).await?;
+    let reply = match schema_type {
+        SchemaType::DocumentStorage => {
+            let values = query_service::query_by_schema(schema_id.to_string(), address)
+                .await
+                .map_err(Error::QueryError)?;
+            warp::reply::json(&byte_map_to_json_map(values)?)
+        }
+        SchemaType::Timeseries => {
+            let timeseries = query_service_ts::query_by_schema(schema_id.to_string(), address)
+                .await
+                .map_err(Error::QueryError)?;
+            warp::reply::json(&(timeseries))
+        }
+    };
+
+    Ok(reply)
 }
 
 fn byte_map_to_json_map(map: HashMap<String, Vec<u8>>) -> Result<Map<String, Value>, Error> {
@@ -68,19 +119,4 @@ fn byte_map_to_json_map(map: HashMap<String, Vec<u8>>) -> Result<Map<String, Val
             ))
         })
         .collect::<Result<Map<String, Value>, Error>>()
-}
-
-pub async fn query_by_range(
-    start: String,
-    end: String,
-    step: String,
-    object_id: Uuid,
-    cache: Arc<AddressCache>,
-) -> Result<impl warp::Reply, warp::Rejection> {
-    let address = cache.get_address(object_id).await?;
-    let response =
-        query_service_ts::query_by_range(object_id.to_string(), start, end, step, address)
-            .await
-            .map_err(Error::QueryError)?;
-    Ok(warp::reply::json(&response))
 }

--- a/query-router/src/main.rs
+++ b/query-router/src/main.rs
@@ -49,7 +49,10 @@ async fn main() {
         .and(schema_id_filter)
         .and(address_filter.clone())
         .and_then(handler::query_by_schema);
-    let routes = warp::get().and(single_route.or(multiple_route).or(schema_route));
+
+    let routes = warp::post()
+        .and(single_route)
+        .or(warp::get().and(multiple_route.or(schema_route)));
 
     warp::serve(routes)
         .run(([0, 0, 0, 0], config.input_port))

--- a/query-router/src/main.rs
+++ b/query-router/src/main.rs
@@ -1,4 +1,4 @@
-use cache::AddressCache;
+use cache::{AddressCache, SchemaTypeCache};
 use std::sync::Arc;
 use structopt::StructOpt;
 use utils::metrics;
@@ -28,15 +28,25 @@ async fn main() {
     metrics::serve();
 
     let address_cache = Arc::new(AddressCache::new(
+        config.schema_registry_addr.clone(),
+        config.cache_capacity,
+    ));
+
+    let schema_type_cache = Arc::new(SchemaTypeCache::new(
         config.schema_registry_addr,
         config.cache_capacity,
     ));
+
     let address_filter = warp::any().map(move || address_cache.clone());
+    let schema_type_filter = warp::any().map(move || schema_type_cache.clone());
     let schema_id_filter = warp::header::header::<Uuid>("SCHEMA_ID");
+    let body_filter = warp::body::content_length_limit(1024 * 32).and(warp::body::json());
 
     let single_route = warp::path!("single" / Uuid)
         .and(schema_id_filter)
         .and(address_filter.clone())
+        .and(schema_type_filter.clone())
+        .and(body_filter)
         .and_then(handler::query_single);
     let multiple_route = warp::path!("multiple" / String)
         .and(schema_id_filter)
@@ -45,17 +55,9 @@ async fn main() {
     let schema_route = warp::path!("schema")
         .and(schema_id_filter)
         .and(address_filter.clone())
+        .and(schema_type_filter.clone())
         .and_then(handler::query_by_schema);
-    let range_route = warp::path!("range" / String / String / String)
-        .and(schema_id_filter)
-        .and(address_filter)
-        .and_then(handler::query_by_range);
-    let routes = warp::get().and(
-        single_route
-            .or(multiple_route)
-            .or(schema_route)
-            .or(range_route),
-    );
+    let routes = warp::get().and(single_route.or(multiple_route).or(schema_route));
 
     warp::serve(routes)
         .run(([0, 0, 0, 0], config.input_port))


### PR DESCRIPTION
Query-router will now:
- using **schema_id** check in `schema-registry`, type of schema and route request either to `query-service` or to `query-service-ts`
- additional parameters (such as range and step needed to query timeseries data) is passed to `query-router` in requests http body

Issue: #15 
BREAKING CHANGE: endpoint `GET /single/<Uuid>` will be changed to HTTP POST and require request body