### PR TITLE
Fix(query-service-ts): escaping for querying by schema_id

### DIFF
--- a/query-service-ts/src/victoria.rs
+++ b/query-service-ts/src/victoria.rs
@@ -111,7 +111,10 @@ impl Query for VictoriaQuery {
         &self,
         request: Request<SchemaId>,
     ) -> Result<Response<TimeSeries>, Status> {
-        let query = ([("query", request.into_inner().schema_id)]);
+        let query = [(
+            "query",
+            format!("{{_name_=\"{}\"}}", request.into_inner().schema_id),
+        )];
 
         let response: String = self.query_db(&query).await?;
         Ok(tonic::Response::new(TimeSeries {


### PR DESCRIPTION
Without this fix, querying by schema_id: "4ab696a4-3b9d-11eb-8002-000000000000"  causes such errors:

```
victoria_metrics_1  | 2020-12-11T10:54:58.545Z    warn    VictoriaMetrics/app/vmselect/main.go:295    error in "/api/v1/query_range?query=4ab696a4-3b9d-11eb-8002-000000000000": error when executing query="4ab696a4-3b9d-11eb-8002-000000000000" on the time range (start=1607683798000, end=1607684098000, step=300000): cannot execute query: unparsed data left: "ab696a4-3b9d-11eb-8002-000000000000"
```


