### PR TITLE
fix(leader-elector): non-default namespace support

### DIFF
--- a/helm/helm-infrastructure/values.yaml
+++ b/helm/helm-infrastructure/values.yaml
@@ -95,6 +95,7 @@ rabbitmq:
 
 kafka:
   replicaCount: 1
+  autoCreateTopicsEnable: true
   zookeeper:
     enabled: true
 

--- a/leader-elector/src/main.rs
+++ b/leader-elector/src/main.rs
@@ -7,7 +7,7 @@ use kube::{
 };
 use log::{info, warn};
 use serde::Deserialize;
-use std::{env, time::Duration};
+use std::{fs, time::Duration};
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -21,6 +21,7 @@ pub struct Config {
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let config = envy::from_env::<Config>().context("Env vars not set correctly")?;
+    let namespace = get_k8s_namespace();
     let schema_elector = LeaderElector {
         master_addr: format!("{}-master", config.schema_addr),
         slave_addr: config.schema_addr,
@@ -28,6 +29,7 @@ async fn main() -> anyhow::Result<()> {
         name: config.schema_app_name,
         election_type: LeaderElectorType::Schema,
         port: config.schema_port,
+        namespace
     };
 
     schema_elector.elect_leader().await
@@ -45,13 +47,13 @@ struct LeaderElector {
     port: u16,
     heartbeat_time: Duration,
     election_type: LeaderElectorType,
+    namespace:String
 }
 
 impl LeaderElector {
     pub async fn elect_leader(&self) -> anyhow::Result<()> {
         let client_api = Client::try_default().await?;
-        let namespace = env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
-        let pods: Api<Pod> = Api::namespaced(client_api, &namespace);
+        let pods: Api<Pod> = Api::namespaced(client_api, &self.namespace);
         loop {
             tokio::time::delay_for(self.heartbeat_time).await;
 
@@ -111,10 +113,14 @@ impl LeaderElector {
 }
 
 fn schema_heartbeat(addr: &str, port: u16) -> impl Future<Output = anyhow::Result<()>> + '_ {
-    schema_registry::heartbeat(format!("{}:{}", addr, port)).map(|x| x.map_err(anyhow::Error::new))
+        schema_registry::heartbeat(format!("{}:{}", addr, port)).map(|x| x.map_err(anyhow::Error::new))
 }
 
 fn schema_promotion(addr: &str, port: u16) -> impl Future<Output = anyhow::Result<String>> + '_ {
-    schema_registry::promote_to_master(format!("{}:{}", addr, port))
+        schema_registry::promote_to_master(format!("{}:{}", addr, port))
         .map(|x| x.map_err(anyhow::Error::new))
+}
+
+fn get_k8s_namespace()->String{
+        fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace").expect("Not running in k8s environment")
 }

--- a/leader-elector/src/main.rs
+++ b/leader-elector/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
         name: config.schema_app_name,
         election_type: LeaderElectorType::Schema,
         port: config.schema_port,
-        namespace
+        namespace,
     };
 
     schema_elector.elect_leader().await
@@ -47,7 +47,7 @@ struct LeaderElector {
     port: u16,
     heartbeat_time: Duration,
     election_type: LeaderElectorType,
-    namespace:String
+    namespace: String,
 }
 
 impl LeaderElector {
@@ -113,14 +113,15 @@ impl LeaderElector {
 }
 
 fn schema_heartbeat(addr: &str, port: u16) -> impl Future<Output = anyhow::Result<()>> + '_ {
-        schema_registry::heartbeat(format!("{}:{}", addr, port)).map(|x| x.map_err(anyhow::Error::new))
+    schema_registry::heartbeat(format!("{}:{}", addr, port)).map(|x| x.map_err(anyhow::Error::new))
 }
 
 fn schema_promotion(addr: &str, port: u16) -> impl Future<Output = anyhow::Result<String>> + '_ {
-        schema_registry::promote_to_master(format!("{}:{}", addr, port))
+    schema_registry::promote_to_master(format!("{}:{}", addr, port))
         .map(|x| x.map_err(anyhow::Error::new))
 }
 
-fn get_k8s_namespace()->String{
-        fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace").expect("Not running in k8s environment")
+fn get_k8s_namespace() -> String {
+    fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+        .expect("Not running in k8s environment")
 }


### PR DESCRIPTION
- add support for running leader elector on different k8s namespaces
- allows kafka to auto create topics in development k8s environment(should fix  #81)