### PR TITLE
chore: Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.{json,toml,yml,yaml}]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Editorconfig file should help with keeping base formatting of non-rust files(rustfmt takes care of that).
Currently its common to commit some files with and other without new line at the end.