### PR TITLE
Add simple batch decomposition in DataRouter

### DIFF
--- a/data-router/src/main.rs
+++ b/data-router/src/main.rs
@@ -101,7 +101,7 @@ async fn handle_message(
     
 
         // Check if something is an array
-        let value : Value = serde_json::from_str(message.payload()?).unwrap();
+        let value : Value = serde_json::from_str(message.payload()?).context("Payload detection failed, message is not in json format")?;
         if value.is_array() {
             let arr_messages: Vec<DataRouterInputData> = serde_json::from_str(message.payload()?)?;
             for event in arr_messages.iter(){


### PR DESCRIPTION
I would like to send multiple cdl messages inside one MQ message,
Messages should look like this:
```
(pseudocode)
[ 
  {id:1,schema:1,data:{}}
  {id:2,schema:1,data:{}}
  {id:3,schema:1,data:{}}
  {id:4,schema:2,data:{}}
  {id:5,schema:3,data:{}}
]
```
decomposition should in this case look (at this point) as 5 separate messages containing one message each, without array