### PR TITLE
chore: update tokio to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream 0.3.0",
+ "async-stream",
  "env_logger 0.8.2",
  "futures",
  "juniper",
@@ -126,17 +126,11 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "utils",
  "uuid",
- "warp",
+ "warp 0.2.5",
 ]
-
-[[package]]
-name = "arc-swap"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "array_tool"
@@ -157,47 +151,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "async-compression"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1ff21a63d3262af46b9f33a826a8d134e2d0d9b2179c86034948b732ea8b2a"
-dependencies = [
- "bytes 0.5.6",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite 0.1.11",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
-dependencies = [
- "async-stream-impl 0.2.1",
- "futures-core",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
 dependencies = [
- "async-stream-impl 0.3.0",
+ "async-stream-impl",
  "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -275,12 +235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,26 +248,27 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bb8"
-version = "0.4.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374bba43fc924d90393ee7768e6f75d223a98307a488fe5bc34b66c3e96932a6"
+checksum = "dae93eccab998c4b8703e3a6bbaa1714c38e445ebacb4bede25d0408521e293c"
 dependencies = [
  "async-trait",
- "futures",
- "tokio 0.2.24",
+ "futures-channel",
+ "futures-util",
+ "parking_lot 0.11.1",
+ "tokio 1.2.0",
 ]
 
 [[package]]
 name = "bb8-postgres"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a233af6ea3952e20d01863c87b4f6689b2f806249688b0908b5f02d4fa41ac"
+checksum = "61fdf56d52b2cca401d2380407e5c35d3d25d3560224ecf74d6e4ca13e51239b"
 dependencies = [
  "async-trait",
  "bb8",
- "futures",
- "tokio 0.2.24",
- "tokio-postgres 0.5.5",
+ "tokio 1.2.0",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -328,7 +283,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "uuid",
 ]
 
@@ -337,15 +292,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "bitvec"
@@ -457,11 +403,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "rpc",
- "semver 0.11.0",
+ "semver",
  "serde",
  "serde_json",
  "structopt",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "tonic",
  "uuid",
 ]
@@ -488,7 +434,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time",
  "winapi 0.3.9",
 ]
 
@@ -558,7 +504,8 @@ dependencies = [
  "structopt",
  "test-case",
  "thiserror",
- "tokio 0.2.24",
+ "tokio 1.2.0",
+ "tokio-stream",
  "tonic",
  "url",
  "utils",
@@ -567,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "cookie-factory"
@@ -617,7 +564,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-channel 0.4.4",
  "crossbeam-deque",
- "crossbeam-epoch",
+ "crossbeam-epoch 0.8.2",
  "crossbeam-queue",
  "crossbeam-utils 0.7.2",
 ]
@@ -648,7 +595,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch",
+ "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
@@ -664,7 +611,21 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.1",
+ "lazy_static",
+ "memoffset 0.6.1",
  "scopeguard",
 ]
 
@@ -703,16 +664,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
-dependencies = [
- "generic-array 0.14.4",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
@@ -732,6 +683,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+]
+
+[[package]]
 name = "data-router"
 version = "0.1.0"
 dependencies = [
@@ -743,7 +704,8 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "tokio 0.2.24",
+ "tokio 1.2.0",
+ "tokio-stream",
  "utils",
  "uuid",
 ]
@@ -828,12 +790,6 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "doc-comment"
@@ -936,18 +892,6 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "flate2"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1211,20 +1155,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+dependencies = [
+ "bytes 1.0.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.2.0",
+ "tokio-util 0.6.3",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hdrhistogram"
-version = "6.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d331ebcdbca4acbefe5da8c3299b2e246f198a8294cc5163354e743398b89d"
-dependencies = [
- "byteorder",
- "num-traits",
-]
 
 [[package]]
 name = "headers"
@@ -1239,7 +1193,7 @@ dependencies = [
  "http",
  "mime",
  "sha-1 0.8.2",
- "time 0.1.44",
+ "time",
 ]
 
 [[package]]
@@ -1277,21 +1231,11 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hmac"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
-dependencies = [
- "crypto-mac 0.9.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.10.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -1313,6 +1257,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.0",
  "http",
 ]
 
@@ -1353,13 +1307,13 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.5",
  "socket2",
  "tokio 0.2.24",
  "tower-service",
@@ -1368,16 +1322,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.4.3"
+name = "hyper"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
- "bytes 0.5.6",
- "hyper",
+ "bytes 1.0.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.0",
+ "http",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.5",
+ "socket2",
+ "tokio 1.2.0",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.4",
+ "pin-project-lite 0.2.4",
+ "tokio 1.2.0",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.0",
+ "hyper 0.14.4",
  "native-tls",
- "tokio 0.2.24",
- "tokio-tls",
+ "tokio 1.2.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1389,20 +1379,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1442,6 +1418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes 1.0.0",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,9 +1452,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -1503,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath_lib"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8727f6987896c010ec9add275f59de2ae418b672fafa77bc3673b4cee1f09ca"
+checksum = "61352ec23883402b7d30b3313c16cbabefb8907361c4eb669d990cbb87ceee5a"
 dependencies = [
  "array_tool",
  "env_logger 0.7.1",
@@ -1529,9 +1514,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "percent-encoding",
  "regex",
- "reqwest",
  "serde_json",
- "structopt",
  "url",
 ]
 
@@ -1605,17 +1588,17 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio 0.2.24",
- "warp",
+ "warp 0.2.5",
 ]
 
 [[package]]
 name = "k8s-openapi"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaa8ea719de24e21fe6fddb2ea996ca4e312d467c119f827551c4768d97dc5c"
+checksum = "bcc1f973542059e6d5a6d63de6a9539d0ec784f82b2327f3c1915d33200bc6a4"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "chrono",
  "serde",
  "serde-value",
@@ -1634,32 +1617,36 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.45.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0ab63beb2437861eba0fcda75b5feb9ef1c0990e63ac22cca0ef9adc4dad74"
+checksum = "459b1593a538fd0bb77e7133fdd3158c55e183affd0926337fa873986a741e0b"
 dependencies = [
  "Inflector",
- "base64 0.12.3",
- "bytes 0.5.6",
+ "base64 0.13.0",
+ "bytes 1.0.0",
  "chrono",
  "dirs-next",
  "either",
  "futures",
- "futures-util",
  "http",
+ "hyper 0.14.4",
+ "hyper-timeout",
+ "hyper-tls",
  "jsonpath_lib",
  "k8s-openapi",
  "log",
  "openssl",
  "pem",
- "reqwest",
+ "pin-project 1.0.5",
  "serde",
  "serde_json",
  "serde_yaml",
  "static_assertions",
  "thiserror",
- "time 0.2.23",
- "tokio 0.2.24",
+ "tokio 1.2.0",
+ "tokio-native-tls",
+ "tokio-util 0.6.3",
+ "tower",
  "url",
 ]
 
@@ -1702,7 +1689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "tokio 0.2.24",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -1779,6 +1766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,107 +1808,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.12.1"
+name = "memoffset"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b70227ece8711a1aa2f99655efd795d0cff297a5b9fe39645a93aacf6ad39d"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
- "metrics-core",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
-name = "metrics-core"
-version = "0.5.2"
+name = "metrics"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c064b3a1ff41f4bf6c91185c8a0caeccf8a8a27e9d0f92cc54cf3dbec812f48"
+checksum = "ee607b70506ed8dbabe467f24ce0a4d0568980993f94c0a7652d2d50e8b51fd1"
+dependencies = [
+ "metrics-macros",
+ "proc-macro-hack",
+]
 
 [[package]]
-name = "metrics-exporter-http"
+name = "metrics-exporter-prometheus"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14017d204ae062dc5c68a321e3dbdcd9b30181305cb6b067932f7f03f754e27"
+checksum = "8d23bb354bd7dd5d244f2e9a389a0c3249bb6b994aca71bd6c2f7cd6fa2657fc"
 dependencies = [
- "hyper",
- "log",
- "metrics-core",
-]
-
-[[package]]
-name = "metrics-exporter-log"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3fc63816bd5f8bde5eb31ce471f9633adc69ba1c55b44191b4d5fc7e263e8ab"
-dependencies = [
- "log",
- "metrics-core",
- "tokio 0.2.24",
-]
-
-[[package]]
-name = "metrics-observer-json"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe930460a6c336b8f873dcfb28da3f805fd0dbadbea7beaf3042c7fb1d9fcd3"
-dependencies = [
- "hdrhistogram",
- "metrics-core",
- "metrics-util",
- "serde_json",
-]
-
-[[package]]
-name = "metrics-observer-prometheus"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfe24ad8285ef8b239232135a65f89cc5fa4690bbfaf8907f4bef38f8b08eba"
-dependencies = [
- "hdrhistogram",
- "metrics-core",
- "metrics-util",
-]
-
-[[package]]
-name = "metrics-observer-yaml"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f66811013592560efc75d75a92d6e2f415a11b52f085e51d9fb4d1edec6335"
-dependencies = [
- "hdrhistogram",
- "metrics-core",
- "metrics-util",
- "serde_yaml",
-]
-
-[[package]]
-name = "metrics-runtime"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0e4f69639ccc0c6b2f0612164f9817349eb25545ed1ffb5ef3e1e1c1d220b4"
-dependencies = [
- "arc-swap",
- "atomic-shim",
- "crossbeam-utils 0.7.2",
- "im",
+ "hyper 0.14.4",
  "metrics",
- "metrics-core",
- "metrics-exporter-http",
- "metrics-exporter-log",
- "metrics-observer-json",
- "metrics-observer-prometheus",
- "metrics-observer-yaml",
  "metrics-util",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.1",
  "quanta",
+ "thiserror",
+ "tokio 1.2.0",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ac60cd4d3a869fd39d57baf0ed7f79fb677580d8d6655c4330d4f1126bc27b"
+dependencies = [
+ "lazy_static",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.3.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277619f040719a5a23d75724586d5601286e8fa53451cfaaca3b8c627c2c2378"
+checksum = "1679edddfd4f95e183e10f9886dcab2b0f07afd0f5e9f8c9412ad6f6bbefe58a"
 dependencies = [
- "crossbeam-epoch",
- "serde",
+ "aho-corasick",
+ "atomic-shim",
+ "crossbeam-epoch 0.9.1",
+ "crossbeam-utils 0.8.1",
+ "dashmap",
+ "indexmap",
+ "metrics",
+ "ordered-float",
+ "parking_lot 0.11.1",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -1971,17 +1930,6 @@ dependencies = [
  "miow 0.3.6",
  "ntapi",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
 ]
 
 [[package]]
@@ -2174,9 +2122,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2194,9 +2142,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2271,7 +2219,7 @@ checksum = "ff5751d87f7c00ae6403eb1fcbba229b9c76c9a30de8c1cf87182177b168cea2"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "libc",
- "time 0.1.44",
+ "time",
  "winapi 0.3.9",
 ]
 
@@ -2340,11 +2288,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.5",
 ]
 
 [[package]]
@@ -2360,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2414,26 +2362,8 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log",
- "tokio 1.0.1",
- "tokio-postgres 0.7.0",
-]
-
-[[package]]
-name = "postgres-protocol"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4888a0e36637ab38d76cace88c1476937d617ad015f07f6b669cec11beacc019"
-dependencies = [
- "base64 0.13.0",
- "byteorder",
- "bytes 0.5.6",
- "fallible-iterator",
- "hmac 0.9.0",
- "md5",
- "memchr",
- "rand 0.7.3",
- "sha2",
- "stringprep",
+ "tokio 1.2.0",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -2446,26 +2376,12 @@ dependencies = [
  "byteorder",
  "bytes 1.0.0",
  "fallible-iterator",
- "hmac 0.10.1",
+ "hmac",
  "md5",
  "memchr",
  "rand 0.8.3",
  "sha2",
  "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc08a7d94a80665de4a83942fa8db2fdeaf2f123fc0535e384dc4fff251efae"
-dependencies = [
- "bytes 0.5.6",
- "fallible-iterator",
- "postgres-protocol 0.5.3",
- "serde",
- "serde_json",
- "uuid",
 ]
 
 [[package]]
@@ -2476,7 +2392,7 @@ checksum = "5493d9d4613b88b12433aa12890e74e74cd93fdc1e08b7c2aed4768aaae8414c"
 dependencies = [
  "bytes 1.0.0",
  "fallible-iterator",
- "postgres-protocol 0.6.0",
+ "postgres-protocol",
  "serde",
  "serde_json",
  "uuid",
@@ -2544,21 +2460,21 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "heck",
  "itertools",
  "log",
@@ -2572,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2585,23 +2501,26 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "prost",
 ]
 
 [[package]]
 name = "quanta"
-version = "0.3.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21484fda3d8ad7affee37755c77a5d0da527543f0af0c7f731c14e2215645d39"
+checksum = "e76a3afdefd0ce2c0363bf3146271e947782240ea617885dd64e56c4de9fb3c9"
 dependencies = [
  "atomic-shim",
  "ctor",
  "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
  "winapi 0.3.9",
 ]
 
@@ -2617,10 +2536,10 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "utils",
  "uuid",
- "warp",
+ "warp 0.3.0",
 ]
 
 [[package]]
@@ -2638,7 +2557,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "tonic",
  "utils",
  "uuid",
@@ -2649,6 +2568,7 @@ name = "query-service-ts"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bb8",
  "env_logger 0.8.2",
  "log",
@@ -2657,7 +2577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "tonic",
  "utils",
 ]
@@ -2697,7 +2617,7 @@ dependencies = [
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg 0.1.2",
+ "rand_pcg",
  "rand_xorshift",
  "winapi 0.3.9",
 ]
@@ -2713,7 +2633,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -2863,15 +2782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,19 +2791,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
+name = "raw-cpuid"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
 dependencies = [
- "rand_core 0.5.1",
+ "bitflags",
 ]
 
 [[package]]
 name = "rdkafka"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db594dc221933be6f2ad804b997b48a57a63436c26ab924222c28e9a36ad210a"
+checksum = "a8acd8f5c5482fdf89e8878227bafa442d8c4409f6287391c85549ca83626c27"
 dependencies = [
  "futures",
  "libc",
@@ -2902,14 +2812,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 0.2.24",
+ "slab",
+ "tokio 1.2.0",
 ]
 
 [[package]]
 name = "rdkafka-sys"
-version = "2.1.0+1.5.0"
+version = "3.0.0+1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3f17044cba41c7309facedc72ca9bf25f177bf1e06756318e010f043713017"
+checksum = "ca35e95c88e08cdc643b25744e38ccee7c93c7e90d1ac6850fe74cbaa40803c3"
 dependencies = [
  "cmake",
  "libc",
@@ -2972,34 +2883,32 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
- "async-compression",
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.0",
+ "hyper 0.14.4",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.4",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 0.2.24",
- "tokio-tls",
+ "tokio 1.2.0",
+ "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3024,15 +2933,6 @@ name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "ryu"
@@ -3071,11 +2971,12 @@ dependencies = [
  "lazy_static",
  "log",
  "rpc",
- "semver 0.11.0",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.24",
+ "tokio 1.2.0",
+ "tokio-stream",
  "tonic",
  "url",
  "utils",
@@ -3119,28 +3020,13 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.1",
+ "semver-parser",
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -3255,12 +3141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "sha2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,14 +3169,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.2"
+name = "sketches-ddsketch"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
-dependencies = [
- "bitmaps",
- "typenum",
-]
+checksum = "76a77a8fd93886010f05e7ea0720e569d6d16c65329dbe3ec033bbbccccb017b"
 
 [[package]]
 name = "slab"
@@ -3311,7 +3187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb6824dde66ad33bf20c6e8476f5b82b871bc8bc3c129a10ea2f7dae5060fa3"
 dependencies = [
  "crc32fast",
- "crossbeam-epoch",
+ "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
  "fs2",
  "fxhash",
@@ -3348,68 +3224,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "standback"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"
@@ -3584,44 +3402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,40 +3427,52 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
  "memchr",
  "mio 0.6.23",
- "mio-uds",
- "num_cpus",
  "pin-project-lite 0.1.11",
- "signal-hook-registry",
  "slab",
- "tokio-macros",
- "winapi 0.3.9",
+ "tokio-macros 0.2.6",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.0",
  "libc",
  "memchr",
  "mio 0.7.6",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.11.1",
  "pin-project-lite 0.2.4",
+ "signal-hook-registry",
+ "tokio-macros 1.1.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-amqp"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2938fb5b638e6d8992c304e2426db2de4502f19084b91ec4562d9b45bf896fc4"
+checksum = "4a236324e1e84931e62c22e2ee47688e077aa33a2a95f14d29ab8ec4dbaf9845"
 dependencies = [
  "lapin",
- "tokio 0.2.24",
+ "parking_lot 0.11.1",
+ "tokio 1.2.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite 0.2.4",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -3695,25 +3487,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-postgres"
-version = "0.5.5"
+name = "tokio-macros"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a2482c9fe4dd481723cf5c0616f34afc710e55dcda0944e12e7b3316117892"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
- "async-trait",
- "byteorder",
- "bytes 0.5.6",
- "fallible-iterator",
- "futures",
- "log",
- "parking_lot 0.11.1",
- "percent-encoding",
- "phf",
- "pin-project-lite 0.1.11",
- "postgres-protocol 0.5.3",
- "postgres-types 0.1.3",
- "tokio 0.2.24",
- "tokio-util 0.3.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -3732,33 +3523,22 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project-lite 0.2.4",
- "postgres-protocol 0.6.0",
- "postgres-types 0.2.0",
+ "postgres-protocol",
+ "postgres-types",
  "socket2",
- "tokio 1.0.1",
- "tokio-util 0.6.0",
+ "tokio 1.2.0",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3be913b74b13210c8fe04b17ab833f5a124f45b93d0f99f59fff621f64392a"
+checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
 dependencies = [
- "async-stream 0.3.0",
  "futures-core",
  "pin-project-lite 0.2.4",
- "tokio 1.0.1",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.24",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -3771,7 +3551,20 @@ dependencies = [
  "log",
  "pin-project 0.4.27",
  "tokio 0.2.24",
- "tungstenite",
+ "tungstenite 0.11.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project 1.0.5",
+ "tokio 1.2.0",
+ "tungstenite 0.12.0",
 ]
 
 [[package]]
@@ -3790,17 +3583,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
  "bytes 1.0.0",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.2.4",
- "tokio 1.0.1",
- "tokio-stream",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -3814,29 +3606,28 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
+checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
 dependencies = [
- "async-stream 0.2.1",
+ "async-stream",
  "async-trait",
- "base64 0.12.3",
- "bytes 0.5.6",
+ "base64 0.13.0",
+ "bytes 1.0.0",
  "futures-core",
  "futures-util",
+ "h2 0.3.0",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.0",
+ "hyper 0.14.4",
  "percent-encoding",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "prost",
  "prost-derive",
- "tokio 0.2.24",
- "tokio-util 0.3.1",
+ "tokio 1.2.0",
+ "tokio-stream",
+ "tokio-util 0.6.3",
  "tower",
- "tower-balance",
- "tower-load",
- "tower-make",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3844,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
+checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -3856,181 +3647,35 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.3.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
-dependencies = [
- "futures-core",
- "tower-buffer",
- "tower-discover",
- "tower-layer",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower-balance"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
+checksum = "713c629c07a3a97f741c140e474e7304294fabec66a43a33f0832e98315ab07f"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.27",
- "rand 0.7.3",
+ "pin-project 1.0.5",
+ "rand 0.8.3",
  "slab",
- "tokio 0.2.24",
- "tower-discover",
- "tower-layer",
- "tower-load",
- "tower-make",
- "tower-ready-cache",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio 1.2.0",
+ "tokio-stream",
+ "tokio-util 0.6.3",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
-
-[[package]]
-name = "tower-limit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio 0.2.24",
- "tower-layer",
- "tower-load",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-dependencies = [
- "futures-core",
- "log",
- "pin-project 0.4.27",
- "tokio 0.2.24",
- "tower-discover",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tokio 0.2.24",
- "tower-service",
-]
-
-[[package]]
-name = "tower-ready-cache"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "log",
- "tokio 0.2.24",
- "tower-service",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
-dependencies = [
- "futures-core",
- "pin-project 0.4.27",
- "tokio 0.2.24",
- "tower-layer",
- "tower-service",
-]
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
-
-[[package]]
-name = "tower-timeout"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-dependencies = [
- "pin-project 0.4.27",
- "tokio 0.2.24",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.27",
- "tower-service",
-]
 
 [[package]]
 name = "tracing"
@@ -4092,9 +3737,28 @@ dependencies = [
  "bytes 0.5.6",
  "http",
  "httparse",
- "input_buffer",
+ "input_buffer 0.3.1",
  "log",
  "rand 0.7.3",
+ "sha-1 0.9.2",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.0.0",
+ "http",
+ "httparse",
+ "input_buffer 0.4.0",
+ "log",
+ "rand 0.8.3",
  "sha-1 0.9.2",
  "url",
  "utf-8",
@@ -4204,24 +3868,22 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream 0.3.0",
+ "async-stream",
  "async-trait",
  "futures-util",
- "hyper",
+ "hyper 0.14.4",
  "lapin",
  "lazy_static",
  "log",
  "metrics",
- "metrics-exporter-http",
- "metrics-observer-prometheus",
- "metrics-runtime",
+ "metrics-exporter-prometheus",
  "rdkafka",
  "serde",
  "serde_json",
  "structopt",
  "test-case",
  "thiserror",
- "tokio 0.2.24",
+ "tokio 1.2.0",
  "tokio-amqp",
  "tonic",
  "uuid",
@@ -4281,7 +3943,7 @@ dependencies = [
  "futures",
  "headers",
  "http",
- "hyper",
+ "hyper 0.13.9",
  "log",
  "mime",
  "mime_guess",
@@ -4292,11 +3954,41 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.6.1",
  "tokio 0.2.24",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.11.0",
  "tower-service",
  "tracing",
  "tracing-futures",
  "urlencoding",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
+dependencies = [
+ "bytes 1.0.0",
+ "futures",
+ "headers",
+ "http",
+ "hyper 0.14.4",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding",
+ "pin-project 1.0.5",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.2.0",
+ "tokio-stream",
+ "tokio-tungstenite 0.13.0",
+ "tokio-util 0.6.3",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -4391,11 +4083,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/benchmarking/Cargo.toml
+++ b/benchmarking/Cargo.toml
@@ -19,10 +19,10 @@ path = "src/upload_to_rabbitmq.rs"
 anyhow      = "1.0"
 pbr         = "1.0"
 rand        = "0.8"
-rdkafka     = "0.24"
+rdkafka     = "0.25.0"
 lapin       = "1.6"
 structopt   = "0.3"
 serde_json  = "1.0"
 serde       = { version = "1.0", features = ["derive"] }
 uuid        = { version = "0.8", features = ["v4", "serde"] }
-tokio       = { version = "0.2", features = ["macros", "sync"] }
+tokio       = { version = "1.2.0", features = ["macros", "sync"] }

--- a/benchmarking/src/upload_to_kafka.rs
+++ b/benchmarking/src/upload_to_kafka.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::Mutex;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 use uuid::Uuid;
 
 mod utils;
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // ensure delivery of all messages
-    delay_for(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     context.pb.lock().await.finish_print("done");
 

--- a/benchmarking/src/upload_to_rabbitmq.rs
+++ b/benchmarking/src/upload_to_rabbitmq.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::Mutex;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 use uuid::Uuid;
 
 mod utils;
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
                     .map(|_| ()),
             };
 
-            let mut sender = context.status_sender.lock().await;
+            let sender = context.status_sender.lock().await;
             sender.send(result).await.ok();
 
             context.pb.lock().await.inc();
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // ensure delivery of all messages
-    delay_for(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     context.pb.lock().await.finish_print("done");
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -28,10 +28,10 @@ serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0.62"
 structopt   = "0.3"
 thiserror   = "1.0"
-tokio       = { version = "0.2", default-features = false, features = ["sync", "rt-threaded", "macros"] }
+tokio       = { version = "1.2.0", default-features = false, features = ["sync", "rt", "macros"] }
 uuid        = { version = "0.8", features = ["v4", "serde"] }
-warp        = "0.2"
-reqwest     = { version = "0.10", features = ["json"] }
+warp        = "0.2.0"
+reqwest     = { version = "0.11.0", features = ["json"] }
 async-stream            = "0.3"
 juniper_graphql_ws      = "0.2"
 juniper_warp            = { version = "0.6", features = ["subscriptions"] }

--- a/crates/cdl-cli/Cargo.toml
+++ b/crates/cdl-cli/Cargo.toml
@@ -21,6 +21,6 @@ semver      = { version = "0.11", features = ["serde"] }
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = { version = "1.0" }
 structopt   = "0.3"
-tokio       = { version = "0.2", features = ["macros", "io-std", "io-util", "fs"] }
-tonic       = "0.3"
+tokio       = { version = "1.2.0", features = ["macros"] }
+tonic       = "0.4.0"
 uuid        = { version = "0.8", features = ["v1", "serde"] }

--- a/crates/command-service/Cargo.toml
+++ b/crates/command-service/Cargo.toml
@@ -23,22 +23,23 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-bb8         = "0.4"
+bb8         = "0.7.0"
 env_logger  = "0.8"
 fnv         = "1.0"
 futures     = "0.3"
 log         = "0.4"
-rdkafka     = { version = "0.24", features = ["cmake-build"] }
-reqwest     = "0.10"
+rdkafka     = { version = "0.25.0", features = ["cmake-build"] }
+reqwest     = "0.11.0"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 structopt   = "0.3"
 thiserror   = "1.0"
-tokio       = { version = "0.2", features = ["rt-threaded", "macros", "sync"] }
-tonic       = "0.3"
+tokio       = { version = "1.2.0", features = ["rt-multi-thread", "macros", "sync"] }
+tokio-stream= { version = "0.1.0" }
+tonic       = "0.4.0"
 url         = "2.1"
 uuid        = { version = "0.8", features = ["v1", "serde"] }
-bb8-postgres            = { version = "0.4", features = ["with-uuid-0_8", "with-serde_json-1"] }
+bb8-postgres            = { version = "0.7.0", features = ["with-uuid-0_8", "with-serde_json-1"] }
 
 [dev-dependencies]
 test-case = "1.1"

--- a/crates/command-service/src/communication/mod.rs
+++ b/crates/command-service/src/communication/mod.rs
@@ -4,6 +4,7 @@ use crate::report::{Error, ReportSender};
 use log::trace;
 use std::sync::Arc;
 use utils::message_types::BorrowedInsertMessage;
+use utils::metrics::metrics::counter;
 use utils::metrics::*;
 
 pub mod config;

--- a/crates/command-service/src/input/service/message_queue.rs
+++ b/crates/command-service/src/input/service/message_queue.rs
@@ -4,14 +4,15 @@ use crate::{
     input::Error,
 };
 use futures::stream::select_all;
-use futures::stream::StreamExt;
 use log::{error, trace};
 use std::{process, sync::Arc};
 use tokio::pin;
+use tokio_stream::StreamExt;
 use utils::messaging_system::consumer::CommonConsumer;
 use utils::messaging_system::message::CommunicationMessage;
 use utils::messaging_system::Result;
-use utils::metrics::counter;
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
 use utils::task_limiter::TaskLimiter;
 use utils::{message_types::BorrowedInsertMessage, parallel_task_queue::ParallelTaskQueue};
 
@@ -55,7 +56,7 @@ impl<P: OutputPlugin> MessageQueueInput<P> {
         message: Result<Box<dyn CommunicationMessage>>,
         task_queue: Arc<ParallelTaskQueue>,
     ) -> Result<(), Error> {
-        counter!("cdl.command-service.input-request", 1);
+        counter!("cdl.command_service.input_request", 1);
         let message = message.map_err(Error::FailedReadingMessage)?;
 
         let generic_message = Self::build_message(message.as_ref())?;
@@ -119,7 +120,7 @@ impl<P: OutputPlugin> MessageQueueInput<P> {
         }
         trace!("Stream closed");
 
-        tokio::time::delay_for(tokio::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
         Ok(())
     }

--- a/crates/command-service/src/main.rs
+++ b/crates/command-service/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     debug!("Environment: {:?}", args);
 
-    metrics::serve();
+    metrics::setup_metrics()?;
 
     let communication_config = args.communication_config()?;
 

--- a/crates/command-service/src/output/druid/mod.rs
+++ b/crates/command-service/src/output/druid/mod.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 use utils::message_types::BorrowedInsertMessage;
-use utils::metrics::counter;
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
 use uuid::Uuid;
 
 mod config;
@@ -74,7 +75,7 @@ impl OutputPlugin for DruidOutputPlugin {
                         description: err.to_string(),
                     }),
                     Ok(_) => {
-                        counter!("cdl.command-service.store.druid", 1);
+                        counter!("cdl.command_service.store.druid", 1);
                         Ok(Resolution::Success)
                     }
                 }

--- a/crates/command-service/src/output/psql/mod.rs
+++ b/crates/command-service/src/output/psql/mod.rs
@@ -11,7 +11,9 @@ pub use error::Error;
 use log::{error, trace};
 use serde_json::Value;
 use utils::message_types::BorrowedInsertMessage;
-use utils::{metrics::counter, psql::validate_schema};
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
+use utils::psql::validate_schema;
 
 pub mod config;
 pub mod error;
@@ -86,7 +88,7 @@ impl OutputPlugin for PostgresOutputPlugin {
 
         match store_result {
             Ok(_) => {
-                counter!("cdl.command-service.store.psql", 1);
+                counter!("cdl.command_service.store.psql", 1);
 
                 Resolution::Success
             }

--- a/crates/command-service/src/output/victoria_metrics/mod.rs
+++ b/crates/command-service/src/output/victoria_metrics/mod.rs
@@ -11,7 +11,8 @@ use serde_json::Value;
 use thiserror::Error as DeriveError;
 use url::ParseError;
 use utils::message_types::BorrowedInsertMessage;
-use utils::metrics::counter;
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
 use uuid::Uuid;
 
 pub mod config;
@@ -126,7 +127,7 @@ async fn send_data(url: Url, client: &Client, line_protocol: String) -> Resoluti
     match client.post(url).body(line_protocol).send().await {
         Ok(response) => {
             if matches!(response.status(), StatusCode::OK | StatusCode::NO_CONTENT) {
-                counter!("cdl.command-service.store.victoria_metrics", 1);
+                counter!("cdl.command_service.store.victoria_metrics", 1);
 
                 Resolution::Success
             } else {

--- a/crates/data-router/Cargo.toml
+++ b/crates/data-router/Cargo.toml
@@ -24,5 +24,6 @@ lru-cache   = "0.1"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 structopt   = "0.3"
-tokio       = { version = "0.2", features = ["macros"] }
+tokio       = { version = "1.2.0", features = ["macros"] }
+tokio-stream= { version = "0.1.0" }
 uuid        = { version = "0.8", features = ["v1", "serde"] }

--- a/crates/data-router/src/main.rs
+++ b/crates/data-router/src/main.rs
@@ -10,14 +10,15 @@ use std::{
 };
 use structopt::{clap::arg_enum, StructOpt};
 use tokio::pin;
-use tokio::stream::StreamExt;
+use tokio_stream::StreamExt;
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
 use utils::{
     abort_on_poison,
     message_types::BorrowedInsertMessage,
     messaging_system::{
         consumer::CommonConsumer, message::CommunicationMessage, publisher::CommonPublisher,
     },
-    metrics::{self, counter},
 };
 use utils::{
     current_timestamp, message_types::DataRouterInsertMessage,
@@ -66,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
 
     debug!("Environment {:?}", config);
 
-    metrics::serve();
+    setup_metrics()?;
 
     let consumer = new_consumer(&config, &config.input_topic_or_queue).await?;
     let producer = Arc::new(new_producer(&config).await?);
@@ -103,7 +104,7 @@ async fn main() -> anyhow::Result<()> {
         };
     }
 
-    tokio::time::delay_for(tokio::time::Duration::from_secs(3)).await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
     Ok(())
 }

--- a/crates/leader-elector/Cargo.toml
+++ b/crates/leader-elector/Cargo.toml
@@ -20,11 +20,11 @@ anyhow      = "1.0"
 env_logger  = "0.8"
 envy        = "0.4"
 futures     = "0.3"
-k8s-openapi = { version = "0.10", default-features = false, features = ["v1_18"] }
-kube        = "0.45"
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_18"] }
+kube        = "0.50.0"
 log         = "0.4"
 serde       = "1.0"
 serde_json  = "1.0"
 serde_yaml  = "0.8"
-tokio       = { version = "0.2", features = ["rt-core"] }
+tokio       = { version = "1.2.0", features = ["rt"] }
 futures-util            = "0.3"

--- a/crates/query-router/Cargo.toml
+++ b/crates/query-router/Cargo.toml
@@ -19,11 +19,11 @@ utils       = { path = "../utils/" }
 # Crates.io
 log         = "0.4"
 env_logger  = "0.8"
-warp        = "0.2"
+warp        = "0.3.0"
 anyhow      = "1.0"
 lru-cache   = "0.1"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 structopt   = "0.3"
 uuid        = { version = "0.8", features = ["v1", "serde"] }
-tokio       = { version = "0.2", features = ["macros"] }
+tokio       = { version = "1.2.0", features = ["macros"] }

--- a/crates/query-router/src/error.rs
+++ b/crates/query-router/src/error.rs
@@ -12,12 +12,6 @@ pub enum Error {
 
 impl Reject for Error {}
 
-impl From<Error> for Rejection {
-    fn from(error: Error) -> Rejection {
-        warp::reject::custom(error)
-    }
-}
-
 pub fn recover(rejection: Rejection) -> Result<impl warp::Reply, Rejection> {
     if let Some(error) = rejection.find::<Error>() {
         let message = match error {

--- a/crates/query-router/src/main.rs
+++ b/crates/query-router/src/main.rs
@@ -20,12 +20,12 @@ struct Config {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     let config = Config::from_args();
 
-    metrics::serve();
+    metrics::setup_metrics()?;
 
     let schema_registry_cache = Arc::new(SchemaRegistryCache::new(
         config.schema_registry_addr,
@@ -62,4 +62,6 @@ async fn main() {
     warp::serve(routes)
         .run(([0, 0, 0, 0], config.input_port))
         .await;
+
+    Ok(())
 }

--- a/crates/query-service-ts/Cargo.toml
+++ b/crates/query-service-ts/Cargo.toml
@@ -22,12 +22,13 @@ utils       = { path = "../utils" }
 
 # Crates.io
 anyhow      = "1.0"
-bb8         = "0.4"
+async-trait = "0.1"
+bb8         = "0.7.0"
 log         = "0.4.14"
 env_logger  = "0.8.2"
-reqwest     = { version = "0.10", features = ["json"] }
+reqwest     = { version = "0.11.0", features = ["json"] }
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 structopt   = "0.3"
-tokio       = { version = "0.2", features = ["macros"] }
-tonic       = "0.3"
+tokio       = { version = "1.2.0", features = ["macros"] }
+tonic       = "0.4.0"

--- a/crates/query-service-ts/src/druid.rs
+++ b/crates/query-service-ts/src/druid.rs
@@ -7,7 +7,8 @@ use rpc::query_service_ts::{
 use serde_json::{json, Value};
 use structopt::StructOpt;
 use tonic::{Request, Response, Status};
-use utils::metrics::counter;
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
 
 #[derive(Debug, StructOpt)]
 pub struct DruidConfig {
@@ -19,7 +20,7 @@ pub struct DruidConfig {
 
 pub struct DruidConnectionManager;
 
-#[tonic::async_trait]
+#[async_trait::async_trait]
 impl bb8::ManageConnection for DruidConnectionManager {
     type Connection = Client;
     type Error = reqwest::Error;
@@ -28,8 +29,8 @@ impl bb8::ManageConnection for DruidConnectionManager {
         Ok(Client::new())
     }
 
-    async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-        Ok(conn)
+    async fn is_valid(&self, _conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
@@ -100,7 +101,7 @@ impl QueryServiceTs for DruidQuery {
         &self,
         request: Request<Range>,
     ) -> Result<Response<TimeSeries>, Status> {
-        counter!("cdl.query-service.query-by-range.druid", 1);
+        counter!("cdl.query_service.query_by_range.druid", 1);
 
         let request = request.into_inner();
 
@@ -130,7 +131,7 @@ impl QueryServiceTs for DruidQuery {
         &self,
         request: Request<SchemaId>,
     ) -> Result<Response<TimeSeries>, Status> {
-        counter!("cdl.query-service.query-by-schema.druid", 1);
+        counter!("cdl.query_service.query_by_schema.druid", 1);
 
         let request = request.into_inner();
 
@@ -156,7 +157,7 @@ impl QueryServiceTs for DruidQuery {
         &self,
         request: Request<RawStatement>,
     ) -> Result<Response<ValueBytes>, Status> {
-        counter!("cdl.query-service.query-raw.druid", 1);
+        counter!("cdl.query_service.query_raw.druid", 1);
 
         let request = request.into_inner();
 

--- a/crates/query-service-ts/src/main.rs
+++ b/crates/query-service-ts/src/main.rs
@@ -36,7 +36,7 @@ async fn spawn_server<Q: QueryServiceTs>(service: Q, port: u16) -> anyhow::Resul
 async fn main() -> anyhow::Result<()> {
     let config: Config = Config::from_args();
     env_logger::init();
-    metrics::serve();
+    metrics::setup_metrics()?;
 
     match config.inner {
         ConfigType::Victoria(victoria_config) => {

--- a/crates/query-service-ts/src/victoria.rs
+++ b/crates/query-service-ts/src/victoria.rs
@@ -16,7 +16,7 @@ pub struct VictoriaConfig {
 
 pub struct VictoriaConnectionManager;
 
-#[tonic::async_trait]
+#[async_trait::async_trait]
 impl bb8::ManageConnection for VictoriaConnectionManager {
     type Connection = Client;
     type Error = reqwest::Error;
@@ -25,8 +25,8 @@ impl bb8::ManageConnection for VictoriaConnectionManager {
         Ok(Client::new())
     }
 
-    async fn is_valid(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
-        Ok(conn)
+    async fn is_valid(&self, _conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     fn has_broken(&self, _conn: &mut Self::Connection) -> bool {

--- a/crates/query-service/Cargo.toml
+++ b/crates/query-service/Cargo.toml
@@ -23,14 +23,14 @@ utils       = { path = "../utils" }
 # Crates.io
 log         = "0.4"
 env_logger  = "0.8"
-bb8         = "0.4"
+bb8         = "0.7.0"
 anyhow      = "1.0"
 thiserror   = "1.0"
 structopt   = "0.3"
-tonic       = "0.3"
+tonic       = "0.4.0"
 serde_json  = "1.0"
 serde       = { version = "1.0", features = ["derive"] }
-tokio       = { version = "0.2", features = ["macros"] }
+tokio       = { version = "1.2.0", features = ["macros"] }
 uuid        = { version = "0.8", features = ["v1", "serde"] }
-reqwest     = { version = "0.10", features = ["json"] }
-bb8-postgres            = { version = "0.4", features = ["with-uuid-0_8", "with-serde_json-1"] }
+reqwest     = { version = "0.11.0", features = ["json"] }
+bb8-postgres            = { version = "0.7.0", features = ["with-uuid-0_8", "with-serde_json-1"] }

--- a/crates/query-service/src/main.rs
+++ b/crates/query-service/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
 
     let config: Config = Config::from_args();
 
-    metrics::serve();
+    metrics::setup_metrics()?;
 
     match config.inner {
         ConfigType::Postgres(psql_config) => {

--- a/crates/query-service/src/psql.rs
+++ b/crates/query-service/src/psql.rs
@@ -10,7 +10,9 @@ use serde_json::Value;
 use std::collections::HashMap;
 use structopt::StructOpt;
 use tonic::{Request, Response, Status};
-use utils::{metrics::counter, psql::validate_schema};
+use utils::metrics::metrics::counter;
+use utils::metrics::*;
+use utils::psql::validate_schema;
 use uuid::Uuid;
 
 #[derive(Debug, StructOpt)]
@@ -134,7 +136,7 @@ impl QueryService for PsqlQuery {
 
         trace!("QueryMultiple: {:?}", request);
 
-        counter!("cdl.query-service.query-multiple.psql", 1);
+        counter!("cdl.query_service.query_multiple.psql", 1);
 
         let object_ids: Vec<Uuid> = request
             .object_ids
@@ -173,7 +175,7 @@ impl QueryService for PsqlQuery {
 
         trace!("QueryBySchema: {:?}", request);
 
-        counter!("cdl.query-service.query-by-schema.psql", 1);
+        counter!("cdl.query_service.query_by_schema.psql", 1);
 
         let schema_id = request
             .schema_id
@@ -202,7 +204,7 @@ impl QueryService for PsqlQuery {
         &self,
         request: Request<RawStatement>,
     ) -> Result<Response<ValueBytes>, Status> {
-        counter!("cdl.query-service.query_raw.psql", 1);
+        counter!("cdl.query_service.query_raw.psql", 1);
         let connection = self.connect().await?;
         let messages = connection
             .simple_query(request.into_inner().raw_statement.as_str())

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -10,11 +10,11 @@ name = "rpc"
 path = "src/lib.rs"
 
 [dependencies]
-tonic       = "0.3"
-prost       = "0.6"
+tonic       = "0.4.0"
+prost       = "0.7.0"
 anyhow      = "1.0"
 thiserror   = "1.0"
 serde       = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = { version = "0.3", default-features = false, features = ["prost", "transport"] }
+tonic-build = { version = "0.4.0", default-features = false, features = ["prost", "transport"] }

--- a/crates/schema-registry/Cargo.toml
+++ b/crates/schema-registry/Cargo.toml
@@ -28,14 +28,15 @@ futures     = "0.3"
 log         = "0.4"
 indradb-lib = { git = "https://github.com/jespersm/indradb", branch = "sled", features = ["sled-datastore"] } # We use fork due to reported incompatibility of sled 0.34 with azure k8s. More testing needed before switching to official build.
 jmespatch   = "0.3"
-jsonschema  = "0.6"
+jsonschema  = { version = "0.6.0", default-features = false }
 lazy_static = "1.4"
 semver      = { version = "0.11", features = ["serde"] }
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 thiserror   = "1.0"
-tokio       = { version = "0.2", features = ["macros"] }
-tonic       = "0.3"
+tokio       = { version = "1.2.0", features = ["macros"] }
+tokio-stream= { version = "0.1.0" }
+tonic       = "0.4.0"
 url         = "2.1"
 uuid        = { version = "0.8", features = ["v1", "serde"] }
 chrono      = "0.4.19"

--- a/crates/schema-registry/src/main.rs
+++ b/crates/schema-registry/src/main.rs
@@ -91,7 +91,7 @@ pub async fn main() -> anyhow::Result<()> {
     };
 
     status_endpoints::serve();
-    metrics::serve();
+    metrics::setup_metrics()?;
 
     let data_store = SledDatastore::new(&config.db_name).map_err(RegistryError::ConnectionError)?;
     let registry = SchemaRegistryImpl::new(

--- a/crates/schema-registry/src/replication/master.rs
+++ b/crates/schema-registry/src/replication/master.rs
@@ -33,9 +33,8 @@ pub async fn replicate_db_events(
             return;
         };
 
-        tokio_runtime.enter(|| {
-            send_messages_to_kafka(producer.clone(), config.topic_or_exchange.clone(), event)
-        });
+        let _enter = tokio_runtime.enter();
+        send_messages_to_kafka(producer.clone(), config.topic_or_exchange.clone(), event)
     }
 }
 

--- a/crates/schema-registry/src/replication/slave.rs
+++ b/crates/schema-registry/src/replication/slave.rs
@@ -3,8 +3,8 @@ use crate::db::SchemaDb;
 use anyhow::Context;
 use log::{error, info, trace};
 use std::{process, sync::Arc};
-use tokio::stream::StreamExt;
 use tokio::{pin, sync::oneshot::Receiver};
+use tokio_stream::StreamExt;
 use utils::messaging_system::{
     consumer::CommonConsumer, consumer::CommonConsumerConfig, message::CommunicationMessage,
 };

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -14,25 +14,23 @@ path = "src/lib.rs"
 [dependencies]
 anyhow      = "1.0"
 async-trait = "0.1"
-hyper       = "0.13"
+hyper       = "0.14.4"
 lapin       = "1.4"
 lazy_static = "1.4"
 log         = "0.4"
-metrics     = { version = "0.12", features = ["std"] }
-rdkafka     = { version = "0.24", features = ["cmake-build"] }
+metrics     = { version = "0.14.1", features = ["std"] }
+rdkafka     = { version = "0.25.0", features = ["cmake-build"] }
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = { version = "1.0", features = ["raw_value"] }
 structopt   = "0.3"
 thiserror   = "1.0"
-tokio       = { version = "0.2", features = ["rt-core"] }
-tokio-amqp  = "0.1"
+tokio       = { version = "1.2.0", features = ["rt"] }
+tokio-amqp  = "1.0.0"
 uuid        = { version = "0.8", features = ["v1", "serde"] }
 async-stream            = "0.3"
 futures-util            = "0.3"
-metrics-exporter-http   = "0.3"
-metrics-runtime         = "0.13"
-tonic                   = "0.3"
-metrics-observer-prometheus         = "0.1"
+tonic                   = "0.4.0"
+metrics-exporter-prometheus         = { version = "0.3.0", features=["tokio-exporter"] }
 
 [dev-dependencies]
 test-case = "1.1"

--- a/crates/utils/src/messaging_system/consumer.rs
+++ b/crates/utils/src/messaging_system/consumer.rs
@@ -56,8 +56,8 @@ impl CommonConsumer {
 
     async fn new_kafka(group_id: &str, brokers: &str, topics: &[&str]) -> Result<Self> {
         let consumer: StreamConsumer<DefaultConsumerContext> = ClientConfig::new()
-            .set("group.id", &group_id)
-            .set("bootstrap.servers", &brokers)
+            .set("group.id", group_id)
+            .set("bootstrap.servers", brokers)
             .set("enable.partition.eof", "false")
             .set("session.timeout.ms", "6000")
             .set("enable.auto.commit", "false")
@@ -103,7 +103,7 @@ impl CommonConsumer {
         try_stream! {
             match self {
                 CommonConsumer::Kafka { consumer } => {
-                    let mut message_stream = consumer.start();
+                    let mut message_stream = consumer.stream();
                     while let Some(message) = message_stream.next().await {
                         let message = message?;
                         yield Box::new(KafkaCommunicationMessage{message,consumer:consumer.clone()}) as Box<dyn CommunicationMessage>;

--- a/crates/utils/src/messaging_system/metadata_fetcher.rs
+++ b/crates/utils/src/messaging_system/metadata_fetcher.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use rdkafka::{producer::BaseProducer, ClientConfig};
+use rdkafka::{
+    producer::{BaseProducer, Producer},
+    ClientConfig,
+};
 use tokio_amqp::LapinTokioExt;
 
 use super::Result;
@@ -14,7 +17,7 @@ pub enum MetadataFetcher {
 impl MetadataFetcher {
     pub async fn new_kafka(brokers: &str) -> Result<Self> {
         let producer = ClientConfig::new()
-            .set("bootstrap.servers", &brokers)
+            .set("bootstrap.servers", brokers)
             .create()
             .context("Metadata fetcher creation failed")?;
 

--- a/crates/utils/src/status_endpoints.rs
+++ b/crates/utils/src/status_endpoints.rs
@@ -1,5 +1,6 @@
+use hyper::server::Server;
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use hyper::{Body, Method, Request, Response, StatusCode};
 use lazy_static::lazy_static;
 use std::convert::Infallible;
 use std::sync::RwLock;


### PR DESCRIPTION
Are we Tokio 1.0 yet?
- [x] bb8
- [x] bb8-postgres
- [x] hyper
- [x] postgres
- [x] tokio-amqp
- [x] reqwest (https://github.com/seanmonstar/reqwest/issues/1123, https://github.com/seanmonstar/reqwest/pull/1133)
- [x] ~jsonschema~
- [x] kube (https://github.com/clux/kube-rs/issues/339)
- [x] metrics (https://github.com/metrics-rs/metrics/pull/133) Seems to be implemented in https://github.com/metrics-rs/metrics/commit/c46cdeb55c305b157e268873e0fc2af146984629
- [x] tonic (https://github.com/hyperium/tonic/pull/514)
- [x] prost
- [x] warp (https://github.com/seanmonstar/warp/pull/753)
- [x] rdkafka (https://github.com/fede1024/rust-rdkafka/issues/299)
- [ ] juniper_warp (https://github.com/graphql-rust/juniper/pull/888)