### PR TITLE
feat: custom kafka acknowledgments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4225,6 +4225,7 @@ dependencies = [
  "tokio-amqp",
  "tonic",
  "uuid",
+ "vec_map",
 ]
 
 [[package]]

--- a/crates/command-service/src/input/service/message_queue.rs
+++ b/crates/command-service/src/input/service/message_queue.rs
@@ -64,7 +64,7 @@ impl<P: OutputPlugin> MessageQueueInput<P> {
 
         let _guard = generic_message
             .order_group_id
-            .map( move |x | async move{ task_queue.acquire_permit(x.to_string()).await});
+            .map(move |x| async move { task_queue.acquire_permit(x.to_string()).await });
 
         router
             .handle_message(generic_message)

--- a/crates/command-service/src/input/service/message_queue.rs
+++ b/crates/command-service/src/input/service/message_queue.rs
@@ -64,7 +64,7 @@ impl<P: OutputPlugin> MessageQueueInput<P> {
 
         let _guard = generic_message
             .order_group_id
-            .map(async move |x| task_queue.acquire_permit(x.to_string()).await);
+            .map( move |x | async move{ task_queue.acquire_permit(x.to_string()).await});
 
         router
             .handle_message(generic_message)
@@ -107,7 +107,7 @@ impl<P: OutputPlugin> MessageQueueInput<P> {
 
             let task_queue = self.task_queue.clone();
             self.task_limiter
-                .run(async move || {
+                .run(move || async move {
                     if let Err(err) =
                         MessageQueueInput::handle_message(router, message, task_queue).await
                     {

--- a/crates/command-service/src/lib.rs
+++ b/crates/command-service/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 pub mod args;
 pub mod communication;
 pub mod input;

--- a/crates/data-router/src/main.rs
+++ b/crates/data-router/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
                 );
 
                 if !config.monotasking {
-                    task_limiter.run(move || async move { future.await}).await
+                    task_limiter.run(move || async move { future.await }).await
                 } else {
                     future.await;
                 }

--- a/crates/data-router/src/main.rs
+++ b/crates/data-router/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 use anyhow::Context;
 use log::{debug, error, trace};
 use lru_cache::LruCache;
@@ -98,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
                 );
 
                 if !config.monotasking {
-                    task_limiter.run(async move || future.await).await
+                    task_limiter.run(move || async move { future.await}).await
                 } else {
                     future.await;
                 }

--- a/crates/data-router/src/main.rs
+++ b/crates/data-router/src/main.rs
@@ -7,7 +7,7 @@ use rpc::schema_registry::Id;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    panic, process,
+    process,
     sync::{Arc, Mutex},
 };
 use structopt::{clap::arg_enum, StructOpt};
@@ -59,13 +59,9 @@ struct Config {
     #[structopt(long, env)]
     pub cache_capacity: usize,
     #[structopt(long, env)]
-    pub monotasking: bool,#
-    [structopt(
-        long = "task-limit",
-        env = "TASK_LIMIT",
-        default_value = "128"
-    )]
-    pub task_limit: usize
+    pub monotasking: bool,
+    #[structopt(long = "task-limit", env = "TASK_LIMIT", default_value = "128")]
+    pub task_limit: usize,
 }
 
 #[tokio::main]
@@ -102,15 +98,10 @@ async fn main() -> anyhow::Result<()> {
                 );
 
                 if !config.monotasking {
-                    task_limiter
-                    .run(
-                        async move || future.await,
-                    )
-                    .await
+                    task_limiter.run(async move || future.await).await
                 } else {
                     future.await;
                 }
-                
             }
             Err(error) => {
                 error!("Error fetching data from message queue {:?}", error);

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -27,6 +27,7 @@ thiserror   = "1.0"
 tokio       = { version = "0.2", features = ["rt-core"] }
 tokio-amqp  = "0.1"
 uuid        = { version = "0.8", features = ["v1", "serde"] }
+vec_map     = "0.8"
 async-stream            = "0.3"
 futures-util            = "0.3"
 metrics-exporter-http   = "0.3"

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(linked_list_cursors)]
+
 use log::error;
 use std::{
     process,

--- a/crates/utils/src/messaging_system/kafka_ack_queue.rs
+++ b/crates/utils/src/messaging_system/kafka_ack_queue.rs
@@ -1,0 +1,110 @@
+use std::{cmp::max, collections::LinkedList, sync::Mutex};
+
+use log::trace;
+use rdkafka::{
+    consumer::{DefaultConsumerContext, StreamConsumer},
+    message::BorrowedMessage,
+    Message, Offset, TopicPartitionList,
+};
+use vec_map::VecMap;
+
+use crate::abort_on_poison;
+
+#[derive(Default)]
+pub struct KafkaAckQueue {
+    queue: Mutex<VecMap<KafkaPartitionAckQueue>>,
+}
+impl KafkaAckQueue {
+    pub fn add(&self, message: &BorrowedMessage) {
+        let partition = message.partition() as usize;
+        let mut queue = self.queue.lock().unwrap_or_else(abort_on_poison);
+        let partition_queue = match (*queue).get_mut(partition) {
+            Some(item) => item,
+            None => {
+                let value = KafkaPartitionAckQueue::new(
+                    message.topic().to_owned(),
+                    message.partition().to_owned(),
+                );
+                (*queue).insert(partition, value);
+                (*queue).get_mut(partition).unwrap()
+            }
+        };
+
+        partition_queue.add(message);
+    }
+    pub async fn ack(
+        &self,
+        message: &BorrowedMessage<'_>,
+        consumer: &StreamConsumer<DefaultConsumerContext>,
+    ) {
+        let partition = message.partition() as usize;
+        let mut queue = self.queue.lock().unwrap_or_else(abort_on_poison);
+        let partition_queue = (*queue).get_mut(partition).unwrap();
+        partition_queue.ack(message, consumer);
+    }
+}
+
+#[derive(Debug)]
+pub struct KafkaPartitionAckQueue {
+    waiting_list: LinkedList<i64>,
+    topic: String,
+    partition: i32,
+    last_offset: i64,
+}
+
+impl KafkaPartitionAckQueue {
+    pub fn new(topic: String, partition: i32) -> KafkaPartitionAckQueue {
+        KafkaPartitionAckQueue {
+            partition,
+            topic,
+            waiting_list: LinkedList::new(),
+            last_offset: 0,
+        }
+    }
+
+    pub fn add(&mut self, message: &BorrowedMessage<'_>) {
+        let offset = message.offset();
+        self.waiting_list.push_back(offset);
+        self.last_offset = offset;
+        trace!("Adding offset {} Partition: {}", offset, self.partition);
+    }
+
+    pub fn ack(
+        &mut self,
+        message: &BorrowedMessage<'_>,
+        consumer: &StreamConsumer<DefaultConsumerContext>,
+    ) {
+        let mut offset = message.offset();
+        if *self.waiting_list.front().unwrap() == offset {
+            self.waiting_list.pop_front();
+            offset = if self.waiting_list.is_empty() {
+                max(self.last_offset, offset)
+            } else {
+                self.waiting_list.front().unwrap() - 1
+            };
+            trace!(
+                "Storing offset {} acknowledged msg {}  List: {:?}",
+                offset,
+                message.offset(),
+                self.waiting_list
+            );
+            let mut partition_offsets = TopicPartitionList::new();
+            partition_offsets.add_partition_offset(
+                &self.topic,
+                self.partition,
+                Offset::Offset(offset),
+            );
+            rdkafka::consumer::Consumer::store_offsets(consumer, &partition_offsets).unwrap();
+        } else {
+            trace!("Marking offset {} as processed", offset);
+            let mut item = self.waiting_list.cursor_front_mut();
+            loop {
+                item.move_next();
+                if item.current() == Some(&mut offset) {
+                    item.remove_current();
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/crates/utils/src/messaging_system/kafka_ack_queue.rs
+++ b/crates/utils/src/messaging_system/kafka_ack_queue.rs
@@ -32,7 +32,7 @@ impl KafkaAckQueue {
 
         partition_queue.add(message);
     }
-    pub async fn ack(
+    pub fn ack(
         &self,
         message: &BorrowedMessage<'_>,
         consumer: &StreamConsumer<DefaultConsumerContext>,

--- a/crates/utils/src/messaging_system/message.rs
+++ b/crates/utils/src/messaging_system/message.rs
@@ -2,14 +2,13 @@ use anyhow::Context;
 use async_trait::async_trait;
 use lapin::{message::Delivery, options::BasicAckOptions, Channel};
 use rdkafka::{
-    consumer::CommitMode,
     consumer::{DefaultConsumerContext, StreamConsumer},
     message::BorrowedMessage,
     Message,
 };
 use std::sync::Arc;
 
-use super::Result;
+use super::{kafka_ack_queue::KafkaAckQueue, Result};
 
 #[async_trait]
 pub trait CommunicationMessage: Send + Sync {
@@ -21,6 +20,7 @@ pub trait CommunicationMessage: Send + Sync {
 pub struct KafkaCommunicationMessage<'a> {
     pub(super) message: BorrowedMessage<'a>,
     pub(super) consumer: Arc<StreamConsumer<DefaultConsumerContext>>,
+    pub(super) ack_queue: Arc<KafkaAckQueue>,
 }
 #[async_trait]
 impl<'a> CommunicationMessage for KafkaCommunicationMessage<'a> {
@@ -38,11 +38,9 @@ impl<'a> CommunicationMessage for KafkaCommunicationMessage<'a> {
             .ok_or_else(|| anyhow::anyhow!("Message has no payload"))??)
     }
     async fn ack(&self) -> Result<()> {
-        rdkafka::consumer::Consumer::commit_message(
-            self.consumer.as_ref(),
-            &self.message,
-            CommitMode::Async,
-        )?;
+        self.ack_queue
+            .ack(&self.message, self.consumer.as_ref())
+            .await;
         Ok(())
     }
 }

--- a/crates/utils/src/messaging_system/message.rs
+++ b/crates/utils/src/messaging_system/message.rs
@@ -38,9 +38,7 @@ impl<'a> CommunicationMessage for KafkaCommunicationMessage<'a> {
             .ok_or_else(|| anyhow::anyhow!("Message has no payload"))??)
     }
     async fn ack(&self) -> Result<()> {
-        self.ack_queue
-            .ack(&self.message, self.consumer.as_ref())
-            .await;
+        self.ack_queue.ack(&self.message, self.consumer.as_ref());
         Ok(())
     }
 }

--- a/crates/utils/src/messaging_system/mod.rs
+++ b/crates/utils/src/messaging_system/mod.rs
@@ -1,6 +1,7 @@
 use thiserror::Error as DeriveError;
 
 pub mod consumer;
+mod kafka_ack_queue;
 pub mod message;
 pub mod publisher;
 

--- a/deployment/helm/cdl/values-local.yaml
+++ b/deployment/helm/cdl/values-local.yaml
@@ -22,7 +22,6 @@ leaderElector:
 
 postgres-document:
   commandServiceReplicaCount: 1
-  postgresDbReplicaCount: 1
   postgresConnectionString: "postgres://postgres:CHANGEME@infrastructure-postgresql/CDL"
   postgresUsername: postgres
   postgresPassword: CHANGEME

--- a/deployment/helm/cdl/values.yaml
+++ b/deployment/helm/cdl/values.yaml
@@ -22,7 +22,6 @@ leaderElector:
 
 postgres-document:
   commandServiceReplicaCount: 1
-  postgresDbReplicaCount: 0
   postgresUsername: postgres
   postgresPassword: postgres
   postgresHost: 10.1.1.5


### PR DESCRIPTION
Closes #180 

Adds mechanism for custom kafka acknowledgments - it allows to process data in parallel with proper message acknowledging using  at-least-once guarantee. Kafka offset is committed to broker periodically.
Added task limiter to data router - same as in CS, it protects us from situation when we're processing to many messages at the same time(more time spend on context changes than on actual work).

Unfortunately due to kafka ability to dynamically change  partitions read by consumer(load balancing) we have to keep track of each message(otherwise it would be as simple as keeping track of three numbers). Alternative is to use separate stream per partition - it might be a bit faster solution(in terms of code execution), but will require much more code changes. This solution is worth considering if we encounter performance problems with custom acknowledgment system.