### PR TITLE
chore: change reviewers to round-robin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # These people are automatically picked by github to review new pull requests;
 ###
 
-*     @luke-biel @esavier @smores56 @Kononnable @frondeus
+*     @epiphany-platform/cdl-reviewers 


### PR DESCRIPTION
Change reviewers to be automatically chosen by GitHub.
Closes #288 