### PR TITLE
chore: k8s CI fix - missing cache

### DIFF
--- a/.github/workflows/testing-helm.yml
+++ b/.github/workflows/testing-helm.yml
@@ -42,9 +42,11 @@ jobs:
         run: |
           docker load -i cache_img
           docker tag $(docker images | awk '{print $3}'  | awk 'NR==2') local/cache
+        continue-on-error: true
       - name: Restore cache
         if: steps.cache.outputs.cache-hit == 'true'
         run: DOCKER_BUILDKIT=1 docker build --no-cache --target cache-import .
+        continue-on-error: true
       - name: build cdl images
         run: DOCKER_BUILDKIT=1 ENV=CI ./build.sh
       - name: Build cache
@@ -82,4 +84,3 @@ jobs:
           [[ -z `kubectl get pods --field-selector=status.phase!=Running` ]]
       - name: uninstall cdl rabbitmq
         run: helm uninstall cdl
-

--- a/.github/workflows/testing-helm.yml
+++ b/.github/workflows/testing-helm.yml
@@ -82,3 +82,4 @@ jobs:
           [[ -z `kubectl get pods --field-selector=status.phase!=Running` ]]
       - name: uninstall cdl rabbitmq
         run: helm uninstall cdl
+


### PR DESCRIPTION
On corrupt build cache CI will fallback to full image rebuild.
Don't know what produced this corrupted cache state.