### PR TITLE
feat: Tracing instrument in API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "indexmap",
  "multer",
  "once_cell",
+ "opentelemetry",
  "pin-project-lite",
  "regex",
  "serde",
@@ -166,6 +167,8 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-futures",
  "uuid",
 ]
 
@@ -3488,6 +3491,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
 ]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -32,6 +32,6 @@ uuid        = { version = "0.8", features = ["v4", "serde"] }
 warp        = "0.3"
 reqwest     = { version = "0.11", features = ["json"] }
 async-stream            = "0.3"
-async-graphql           = { version = "2.6", features = ["uuid"] }
+async-graphql           = { version = "2.6", features = ["uuid", "opentelemetry", "tracing-futures", "tracinglib"] }
 async-graphql-warp      = "2.8"
 tracing-futures         = "0.2"

--- a/crates/api/src/schema/mutation.rs
+++ b/crates/api/src/schema/mutation.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Context, FieldResult, Object};
 use num_traits::ToPrimitive;
-use tracing::Instrument;
 use utils::message_types::OwnedInsertMessage;
 use uuid::Uuid;
 
@@ -15,186 +14,193 @@ pub struct MutationRoot;
 
 #[Object]
 impl MutationRoot {
+    #[tracing::instrument(skip(self, context))]
     async fn add_schema(&self, context: &Context<'_>, new: NewSchema) -> FieldResult<Schema> {
-        let span = tracing::info_span!("add_schema", ?new);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
 
-            let rpc_schema_type: i32 = new.schema_type.to_i32().unwrap(); // Unwrap because we for sure can build i32 from enum
+        let rpc_schema_type: i32 = new.schema_type.to_i32().unwrap(); // Unwrap because we for sure can build i32 from enum
 
-            let id = conn
-                .add_schema(rpc::schema_registry::NewSchema {
-                    id: "".into(),
-                    name: new.name.clone(),
-                    query_address: new.query_address.clone(),
-                    insert_destination: new.insert_destination.clone(),
-                    definition: serde_json::to_string(&new.definition)?,
-                    schema_type: rpc_schema_type,
-                })
-                .await
-                .map_err(rpc::error::schema_registry_error)?
-                .into_inner()
-                .id
-                .parse()?;
-
-            Ok(Schema {
-                id,
-                name: new.name,
-                insert_destination: new.insert_destination,
-                query_address: new.query_address,
-                schema_type: new.schema_type,
+        let id = conn
+            .add_schema(rpc::schema_registry::NewSchema {
+                id: "".into(),
+                name: new.name.clone(),
+                query_address: new.query_address.clone(),
+                insert_destination: new.insert_destination.clone(),
+                definition: serde_json::to_string(&new.definition)?,
+                schema_type: rpc_schema_type,
             })
-        }
-        .instrument(span)
-        .await
+            .await
+            .map_err(rpc::error::schema_registry_error)?
+            .into_inner()
+            .id
+            .parse()?;
+
+        Ok(Schema {
+            id,
+            name: new.name,
+            insert_destination: new.insert_destination,
+            query_address: new.query_address,
+            schema_type: new.schema_type,
+        })
     }
 
+    #[tracing::instrument(skip(self, context))]
     async fn add_schema_definition(
         &self,
         context: &Context<'_>,
         schema_id: Uuid,
         new_version: NewVersion,
     ) -> FieldResult<Definition> {
-        let span = tracing::info_span!("add_schema_definition", ?schema_id, ?new_version);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
 
-            conn.add_schema_version(rpc::schema_registry::NewSchemaVersion {
-                id: schema_id.to_string(),
-                version: new_version.version.clone(),
-                definition: serde_json::to_string(&new_version.definition)?,
-            })
-            .await
-            .map_err(rpc::error::schema_registry_error)?;
-
-            Ok(Definition {
-                definition: new_version.definition,
-                version: new_version.version,
-            })
-        }
-        .instrument(span)
+        conn.add_schema_version(rpc::schema_registry::NewSchemaVersion {
+            id: schema_id.to_string(),
+            version: new_version.version.clone(),
+            definition: serde_json::to_string(&new_version.definition)?,
+        })
         .await
+        .map_err(rpc::error::schema_registry_error)?;
+
+        Ok(Definition {
+            definition: new_version.definition,
+            version: new_version.version,
+        })
     }
 
+    #[tracing::instrument(skip(self, context))]
     async fn add_view(
         &self,
         context: &Context<'_>,
         schema_id: Uuid,
         new_view: NewView,
     ) -> FieldResult<View> {
-        let span = tracing::info_span!("add_view", ?schema_id, ?new_view);
-        async move {
-            let NewView {
+        let NewView {
+            name,
+            materializer_addr,
+            materializer_options,
+            fields,
+        } = new_view.clone();
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let id = conn
+            .add_view_to_schema(rpc::schema_registry::NewSchemaView {
+                schema_id: schema_id.to_string(),
+                view_id: "".into(),
                 name,
                 materializer_addr,
-                materializer_options,
-                fields,
-            } = new_view.clone();
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
-            let id = conn
-                .add_view_to_schema(rpc::schema_registry::NewSchemaView {
-                    schema_id: schema_id.to_string(),
-                    view_id: "".into(),
-                    name,
-                    materializer_addr,
-                    materializer_options: serde_json::to_string(&materializer_options)?,
-                    fields: serde_json::to_string(&fields)?,
-                })
-                .await
-                .map_err(rpc::error::schema_registry_error)?
-                .into_inner()
-                .id;
-
-            Ok(View {
-                id: id.parse()?,
-                name: new_view.name,
-                materializer_addr: new_view.materializer_addr,
-                fields: new_view.fields,
+                materializer_options: serde_json::to_string(&materializer_options)?,
+                fields: serde_json::to_string(&fields)?,
             })
-        }
-        .instrument(span)
-        .await
+            .await
+            .map_err(rpc::error::schema_registry_error)?
+            .into_inner()
+            .id;
+
+        Ok(View {
+            id: id.parse()?,
+            name: new_view.name,
+            materializer_addr: new_view.materializer_addr,
+            fields: new_view.fields,
+        })
     }
 
+    #[tracing::instrument(skip(self, context))]
     async fn update_view(
         &self,
         context: &Context<'_>,
         id: Uuid,
         update: UpdateView,
     ) -> FieldResult<View> {
-        let span = tracing::info_span!("update_view", ?id, ?update);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
 
-            let UpdateView {
-                name,
-                materializer_addr,
-                materializer_options,
-                fields,
-            } = update;
+        let UpdateView {
+            name,
+            materializer_addr,
+            materializer_options,
+            fields,
+        } = update;
 
-            conn.update_view(rpc::schema_registry::UpdatedView {
-                id: id.to_string(),
-                name: name.clone(),
-                materializer_addr: materializer_addr.clone(),
-                materializer_options: materializer_options
-                    .as_ref()
-                    .map(|o| serde_json::to_string(o))
-                    .transpose()?,
-                fields: fields
-                    .as_ref()
-                    .map(|f| serde_json::to_string(f))
-                    .transpose()?,
-            })
-            .await
-            .map_err(rpc::error::schema_registry_error)?;
-
-            get_view(&mut conn, id).await
-        }
-        .instrument(span)
+        conn.update_view(rpc::schema_registry::UpdatedView {
+            id: id.to_string(),
+            name: name.clone(),
+            materializer_addr: materializer_addr.clone(),
+            materializer_options: materializer_options
+                .as_ref()
+                .map(|o| serde_json::to_string(o))
+                .transpose()?,
+            fields: fields
+                .as_ref()
+                .map(|f| serde_json::to_string(f))
+                .transpose()?,
+        })
         .await
+        .map_err(rpc::error::schema_registry_error)?;
+
+        get_view(&mut conn, id).await
     }
 
+    #[tracing::instrument(skip(self, context))]
     async fn update_schema(
         &self,
         context: &Context<'_>,
         id: Uuid,
         update: UpdateSchema,
     ) -> FieldResult<Schema> {
-        let span = tracing::info_span!("update_schema", ?id, ?update);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
 
-            let UpdateSchema {
-                name,
-                query_address: address,
-                insert_destination,
-                schema_type,
-            } = update;
+        let UpdateSchema {
+            name,
+            query_address: address,
+            insert_destination,
+            schema_type,
+        } = update;
 
-            conn.update_schema_metadata(rpc::schema_registry::SchemaMetadataUpdate {
-                id: id.to_string(),
-                name,
-                address,
-                insert_destination,
-                schema_type: schema_type.and_then(|s| s.to_i32()),
-            })
-            .await
-            .map_err(rpc::error::schema_registry_error)?;
-            get_schema(&mut conn, id).await
-        }
-        .instrument(span)
+        conn.update_schema_metadata(rpc::schema_registry::SchemaMetadataUpdate {
+            id: id.to_string(),
+            name,
+            address,
+            insert_destination,
+            schema_type: schema_type.and_then(|s| s.to_i32()),
+        })
         .await
+        .map_err(rpc::error::schema_registry_error)?;
+        get_schema(&mut conn, id).await
     }
 
+    #[tracing::instrument(skip(self, context))]
     async fn insert_message(
         &self,
         context: &Context<'_>,
         message: InputMessage,
     ) -> FieldResult<bool> {
-        let span = tracing::info_span!("insert_message", ?message.object_id, ?message.schema_id);
-        async move {
-            let publisher = connect_to_cdl_input(context.data_unchecked::<Config>()).await?;
+        let publisher = connect_to_cdl_input(context.data_unchecked::<Config>()).await?;
+        let payload = serde_json::to_vec(&OwnedInsertMessage {
+            object_id: message.object_id,
+            schema_id: message.schema_id,
+            data: message.payload.0,
+            timestamp: current_timestamp(),
+        })?;
+
+        publisher
+            .publish_message(
+                &context.data_unchecked::<Config>().insert_destination,
+                "",
+                payload,
+            )
+            .await
+            .map_err(Error::PublisherError)?;
+        Ok(true)
+    }
+
+    #[tracing::instrument(skip(self, context))]
+    async fn insert_batch(
+        &self,
+        context: &Context<'_>,
+        messages: Vec<InputMessage>,
+    ) -> FieldResult<bool> {
+        let publisher = connect_to_cdl_input(context.data_unchecked::<Config>()).await?;
+        let order_group_id = Uuid::new_v4().to_string();
+
+        for message in messages {
             let payload = serde_json::to_vec(&OwnedInsertMessage {
                 object_id: message.object_id,
                 schema_id: message.schema_id,
@@ -205,50 +211,16 @@ impl MutationRoot {
             publisher
                 .publish_message(
                     &context.data_unchecked::<Config>().insert_destination,
-                    "",
+                    &order_group_id,
                     payload,
                 )
                 .await
                 .map_err(Error::PublisherError)?;
-            Ok(true)
         }
-        .instrument(span)
-        .await
+        Ok(true)
     }
 
-    async fn insert_batch(
-        &self,
-        context: &Context<'_>,
-        messages: Vec<InputMessage>,
-    ) -> FieldResult<bool> {
-        let span = tracing::info_span!("insert_batch", len = messages.len());
-        async move {
-            let publisher = connect_to_cdl_input(context.data_unchecked::<Config>()).await?;
-            let order_group_id = Uuid::new_v4().to_string();
-
-            for message in messages {
-                let payload = serde_json::to_vec(&OwnedInsertMessage {
-                    object_id: message.object_id,
-                    schema_id: message.schema_id,
-                    data: message.payload.0,
-                    timestamp: current_timestamp(),
-                })?;
-
-                publisher
-                    .publish_message(
-                        &context.data_unchecked::<Config>().insert_destination,
-                        &order_group_id,
-                        payload,
-                    )
-                    .await
-                    .map_err(Error::PublisherError)?;
-            }
-            Ok(true)
-        }
-        .instrument(span)
-        .await
-    }
-
+    #[tracing::instrument(skip(self, context))]
     /// Add new relation, return generated `relation_id`
     async fn add_relation(
         &self,
@@ -256,51 +228,42 @@ impl MutationRoot {
         parent_schema_id: Uuid,
         child_schema_id: Uuid,
     ) -> FieldResult<Uuid> {
-        let span = tracing::info_span!("add_relation", ?parent_schema_id, ?child_schema_id);
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            Ok(conn
-                .add_relation(rpc::edge_registry::SchemaRelation {
-                    parent_schema_id: parent_schema_id.to_string(),
-                    child_schema_id: child_schema_id.to_string(),
-                })
-                .await?
-                .into_inner()
-                .relation_id
-                .parse()?)
-        }
-        .instrument(span)
-        .await
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        Ok(conn
+            .add_relation(rpc::edge_registry::SchemaRelation {
+                parent_schema_id: parent_schema_id.to_string(),
+                child_schema_id: child_schema_id.to_string(),
+            })
+            .await?
+            .into_inner()
+            .relation_id
+            .parse()?)
     }
 
+    #[tracing::instrument(skip(self, context))]
     /// Add new object-object edges
     async fn add_edges(
         &self,
         context: &Context<'_>,
         relations: Vec<ObjectRelations>,
     ) -> FieldResult<bool> {
-        let span = tracing::info_span!("add_edges", len = relations.len());
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            conn.add_edges(rpc::edge_registry::ObjectRelations {
-                relations: relations
-                    .into_iter()
-                    .map(|relation| rpc::edge_registry::Edge {
-                        relation_id: relation.relation_id.to_string(),
-                        parent_object_id: relation.parent_object_id.to_string(),
-                        child_object_ids: relation
-                            .child_object_ids
-                            .into_iter()
-                            .map(|id| id.to_string())
-                            .collect(),
-                    })
-                    .collect(),
-            })
-            .await?;
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        conn.add_edges(rpc::edge_registry::ObjectRelations {
+            relations: relations
+                .into_iter()
+                .map(|relation| rpc::edge_registry::Edge {
+                    relation_id: relation.relation_id.to_string(),
+                    parent_object_id: relation.parent_object_id.to_string(),
+                    child_object_ids: relation
+                        .child_object_ids
+                        .into_iter()
+                        .map(|id| id.to_string())
+                        .collect(),
+                })
+                .collect(),
+        })
+        .await?;
 
-            Ok(true)
-        }
-        .instrument(span)
-        .await
+        Ok(true)
     }
 }

--- a/crates/api/src/schema/query.rs
+++ b/crates/api/src/schema/query.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use async_graphql::{Context, FieldResult, Json, Object};
 use itertools::Itertools;
 use num_traits::FromPrimitive;
-use tracing::Instrument;
 use uuid::Uuid;
 
 use rpc::object_builder::ViewId;
@@ -48,98 +47,88 @@ impl Schema {
     /// Returns schema definition for given version.
     /// Schema is following semantic versioning, querying for "2.1.0" will return "2.1.1" if exist,
     /// querying for "=2.1.0" will return "2.1.0" if exist
+    #[tracing::instrument(skip(self, context), fields(id))]
     async fn definition(&self, context: &Context<'_>, version: String) -> FieldResult<Definition> {
-        let span = tracing::info_span!("query_definition", ?self.id, ?version);
-        async move {
-            let id = self.id.to_string();
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let id = self.id.to_string();
+        tracing::Span::current().record("id", &id.as_str());
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let schema_def = conn
+            .get_schema(rpc::schema_registry::VersionedId {
+                id,
+                version_req: version,
+            })
+            .await
+            .map_err(rpc::error::schema_registry_error)?
+            .into_inner();
+
+        Ok(Definition {
+            version: schema_def.version,
+            definition: Json(serde_json::from_str(&schema_def.definition)?),
+        })
+    }
+
+    /// All definitions connected to this schema.
+    /// Each schema can have only one active definition, under latest version but also contains history for backward compability.
+    #[tracing::instrument(skip(self, context), fields(id))]
+    async fn definitions(&self, context: &Context<'_>) -> FieldResult<Vec<Definition>> {
+        let id = self.id.to_string();
+        tracing::Span::current().record("id", &id.as_str());
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let rpc_id = rpc::schema_registry::Id { id: id.clone() };
+
+        let versions = conn
+            .get_schema_versions(rpc_id)
+            .await
+            .map_err(rpc::error::schema_registry_error)?
+            .into_inner()
+            .versions;
+
+        let mut definitions = vec![];
+        for version in versions {
             let schema_def = conn
                 .get_schema(rpc::schema_registry::VersionedId {
-                    id,
-                    version_req: version,
+                    id: id.clone(),
+                    version_req: format!("={}", version),
                 })
                 .await
                 .map_err(rpc::error::schema_registry_error)?
                 .into_inner();
 
-            Ok(Definition {
+            definitions.push(Definition {
                 version: schema_def.version,
                 definition: Json(serde_json::from_str(&schema_def.definition)?),
-            })
+            });
         }
-        .instrument(span)
-        .await
-    }
 
-    /// All definitions connected to this schema.
-    /// Each schema can have only one active definition, under latest version but also contains history for backward compability.
-    async fn definitions(&self, context: &Context<'_>) -> FieldResult<Vec<Definition>> {
-        let span = tracing::info_span!("query_definitions", ?self.id);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
-            let id = self.id.to_string();
-            let rpc_id = rpc::schema_registry::Id { id: id.clone() };
-
-            let versions = conn
-                .get_schema_versions(rpc_id)
-                .await
-                .map_err(rpc::error::schema_registry_error)?
-                .into_inner()
-                .versions;
-
-            let mut definitions = vec![];
-            for version in versions {
-                let schema_def = conn
-                    .get_schema(rpc::schema_registry::VersionedId {
-                        id: id.clone(),
-                        version_req: format!("={}", version),
-                    })
-                    .await
-                    .map_err(rpc::error::schema_registry_error)?
-                    .into_inner();
-
-                definitions.push(Definition {
-                    version: schema_def.version,
-                    definition: Json(serde_json::from_str(&schema_def.definition)?),
-                });
-            }
-
-            Ok(definitions)
-        }
-        .instrument(span)
-        .await
+        Ok(definitions)
     }
 
     /// All views connected to this schema
+    #[tracing::instrument(skip(self, context), fields(id))]
     async fn views(&self, context: &Context<'_>) -> FieldResult<Vec<View>> {
-        let span = tracing::info_span!("query_views", ?self.id);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
-            let id = self.id.to_string();
-            let rpc_id = rpc::schema_registry::Id { id: id.clone() };
+        let id = self.id.to_string();
+        tracing::Span::current().record("id", &id.as_str());
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let rpc_id = rpc::schema_registry::Id { id: id.clone() };
 
-            let views = conn
-                .get_all_views_of_schema(rpc_id.clone())
-                .await
-                .map_err(rpc::error::schema_registry_error)?
-                .into_inner()
-                .views
-                .into_iter()
-                .map(|(id, view)| {
-                    Ok(View {
-                        id: id.parse()?,
-                        name: view.name,
-                        materializer_addr: view.materializer_addr,
-                        fields: serde_json::from_str(&view.fields)
-                            .map_err(Error::ViewFieldError)?,
-                    })
+        let views = conn
+            .get_all_views_of_schema(rpc_id.clone())
+            .await
+            .map_err(rpc::error::schema_registry_error)?
+            .into_inner()
+            .views
+            .into_iter()
+            .map(|(id, view)| {
+                Ok(View {
+                    id: id.parse()?,
+                    name: view.name,
+                    materializer_addr: view.materializer_addr,
+                    fields: serde_json::from_str(&view.fields).map_err(Error::ViewFieldError)?,
                 })
-                .collect::<Result<_>>()?;
+            })
+            .collect::<Result<_>>()?;
 
-            Ok(views)
-        }
-        .instrument(span)
-        .await
+        Ok(views)
     }
 }
 
@@ -148,340 +137,292 @@ pub struct QueryRoot;
 #[Object]
 impl QueryRoot {
     /// Return single schema for given id
+    #[tracing::instrument(skip(self, context))]
     async fn schema(&self, context: &Context<'_>, id: Uuid) -> FieldResult<Schema> {
-        let span = tracing::info_span!("query_schema", ?id);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
-            get_schema(&mut conn, id).await
-        }
-        .instrument(span)
-        .await
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        get_schema(&mut conn, id).await
     }
 
     /// Return all schemas in database
+    #[tracing::instrument(skip(self, context))]
     async fn schemas(&self, context: &Context<'_>) -> FieldResult<Vec<Schema>> {
-        let span = tracing::info_span!("query_schemas");
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
-            let schemas = conn
-                .get_all_schemas(Empty {})
-                .await
-                .map_err(rpc::error::schema_registry_error)?
-                .into_inner()
-                .schemas
-                .into_iter()
-                .map(|(schema_id, schema)| {
-                    Ok(Schema {
-                        id: schema_id.parse()?,
-                        name: schema.name,
-                        insert_destination: schema.insert_destination,
-                        query_address: schema.query_address,
-                        schema_type: SchemaType::from_i32(schema.schema_type)
-                            .ok_or(Error::InvalidSchemaType(schema.schema_type))?,
-                    })
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        let schemas = conn
+            .get_all_schemas(Empty {})
+            .await
+            .map_err(rpc::error::schema_registry_error)?
+            .into_inner()
+            .schemas
+            .into_iter()
+            .map(|(schema_id, schema)| {
+                Ok(Schema {
+                    id: schema_id.parse()?,
+                    name: schema.name,
+                    insert_destination: schema.insert_destination,
+                    query_address: schema.query_address,
+                    schema_type: SchemaType::from_i32(schema.schema_type)
+                        .ok_or(Error::InvalidSchemaType(schema.schema_type))?,
                 })
-                .collect::<Result<_>>()?;
+            })
+            .collect::<Result<_>>()?;
 
-            Ok(schemas)
-        }
-        .instrument(span)
-        .await
+        Ok(schemas)
     }
 
     /// Return single view for given id
+    #[tracing::instrument(skip(self, context))]
     async fn view(&self, context: &Context<'_>, id: Uuid) -> FieldResult<View> {
-        let span = tracing::info_span!("query_view", ?id);
-        async move {
-            let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
-            get_view(&mut conn, id).await
-        }
-        .instrument(span)
-        .await
+        let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
+        get_view(&mut conn, id).await
     }
 
     /// Return a single object from the query router
+    #[tracing::instrument(skip(self, context))]
     async fn object(
         &self,
         context: &Context<'_>,
         object_id: Uuid,
         schema_id: Uuid,
     ) -> FieldResult<CdlObject> {
-        let span = tracing::info_span!("query_object", ?object_id, ?schema_id);
-        async move {
-            let client = reqwest::Client::new();
+        let client = reqwest::Client::new();
 
-            let bytes = client
-                .post(&format!(
-                    "{}/single/{}",
-                    &context.data_unchecked::<Config>().query_router_addr,
-                    object_id
-                ))
-                .header("SCHEMA_ID", schema_id.to_string())
-                .body("{}")
-                .send()
-                .await?
-                .bytes()
-                .await?;
+        let bytes = client
+            .post(&format!(
+                "{}/single/{}",
+                &context.data_unchecked::<Config>().query_router_addr,
+                object_id
+            ))
+            .header("SCHEMA_ID", schema_id.to_string())
+            .body("{}")
+            .send()
+            .await?
+            .bytes()
+            .await?;
 
-            Ok(CdlObject {
-                object_id,
-                data: serde_json::from_slice(&bytes[..])?,
-            })
-        }
-        .instrument(span)
-        .await
+        Ok(CdlObject {
+            object_id,
+            data: serde_json::from_slice(&bytes[..])?,
+        })
     }
 
     /// Return a map of objects selected by ID from the query router
+    #[tracing::instrument(skip(self, context))]
     async fn objects(
         &self,
         context: &Context<'_>,
         object_ids: Vec<Uuid>,
         schema_id: Uuid,
     ) -> FieldResult<Vec<CdlObject>> {
-        let span = tracing::info_span!("query_objects", ?object_ids, ?schema_id);
-        async move {
-            let client = reqwest::Client::new();
+        let client = reqwest::Client::new();
 
-            let id_list = object_ids.iter().join(",");
+        let id_list = object_ids.iter().join(",");
 
-            let values: HashMap<Uuid, serde_json::Value> = client
-                .get(&format!(
-                    "{}/multiple/{}",
-                    &context.data_unchecked::<Config>().query_router_addr,
-                    id_list
-                ))
-                .header("SCHEMA_ID", schema_id.to_string())
-                .send()
-                .await?
-                .json()
-                .await?;
+        let values: HashMap<Uuid, serde_json::Value> = client
+            .get(&format!(
+                "{}/multiple/{}",
+                &context.data_unchecked::<Config>().query_router_addr,
+                id_list
+            ))
+            .header("SCHEMA_ID", schema_id.to_string())
+            .send()
+            .await?
+            .json()
+            .await?;
 
-            Ok(values
-                .into_iter()
-                .map(|(object_id, data)| CdlObject {
-                    object_id,
-                    data: Json(data),
-                })
-                .collect::<Vec<CdlObject>>())
-        }
-        .instrument(span)
-        .await
+        Ok(values
+            .into_iter()
+            .map(|(object_id, data)| CdlObject {
+                object_id,
+                data: Json(data),
+            })
+            .collect::<Vec<CdlObject>>())
     }
 
     /// Return a map of all objects (keyed by ID) in a schema from the query router
+    #[tracing::instrument(skip(self, context))]
     async fn schema_objects(
         &self,
         context: &Context<'_>,
         schema_id: Uuid,
     ) -> FieldResult<Vec<CdlObject>> {
-        let span = tracing::info_span!("query_schema_objects", ?schema_id);
-        async move {
-            let client = reqwest::Client::new();
+        let client = reqwest::Client::new();
 
-            let values: HashMap<Uuid, serde_json::Value> = client
-                .get(&format!(
-                    "{}/schema",
-                    &context.data_unchecked::<Config>().query_router_addr,
-                ))
-                .header("SCHEMA_ID", schema_id.to_string())
-                .send()
-                .await?
-                .json()
-                .await?;
+        let values: HashMap<Uuid, serde_json::Value> = client
+            .get(&format!(
+                "{}/schema",
+                &context.data_unchecked::<Config>().query_router_addr,
+            ))
+            .header("SCHEMA_ID", schema_id.to_string())
+            .send()
+            .await?
+            .json()
+            .await?;
 
-            Ok(values
-                .into_iter()
-                .map(|(object_id, data)| CdlObject {
-                    object_id,
-                    data: Json(data),
-                })
-                .collect::<Vec<CdlObject>>())
-        }
-        .instrument(span)
-        .await
+        Ok(values
+            .into_iter()
+            .map(|(object_id, data)| CdlObject {
+                object_id,
+                data: Json(data),
+            })
+            .collect::<Vec<CdlObject>>())
     }
 
     /// Return schema `parent` is in `relation_id` relation with
+    #[tracing::instrument(skip(self, context))]
     async fn relation(
         &self,
         context: &Context<'_>,
         relation_id: Uuid,
         parent_schema_id: Uuid,
     ) -> FieldResult<Option<Uuid>> {
-        let span = tracing::info_span!("query_relation", ?relation_id, ?parent_schema_id);
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            Ok(conn
-                .get_relation(rpc::edge_registry::RelationQuery {
-                    relation_id: relation_id.to_string(),
-                    parent_schema_id: parent_schema_id.to_string(),
-                })
-                .await?
-                .into_inner()
-                .child_schema_id
-                .map(|s| s.parse())
-                .transpose()?)
-        }
-        .instrument(span)
-        .await
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        Ok(conn
+            .get_relation(rpc::edge_registry::RelationQuery {
+                relation_id: relation_id.to_string(),
+                parent_schema_id: parent_schema_id.to_string(),
+            })
+            .await?
+            .into_inner()
+            .child_schema_id
+            .map(|s| s.parse())
+            .transpose()?)
     }
 
     /// Return all relations `parent` is in
+    #[tracing::instrument(skip(self, context))]
     async fn schema_relations(
         &self,
         context: &Context<'_>,
         parent_schema_id: Uuid,
     ) -> FieldResult<Vec<SchemaRelation>> {
-        let span = tracing::info_span!("query_schema_relations", ?parent_schema_id);
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            conn.get_schema_relations(rpc::edge_registry::SchemaId {
-                schema_id: parent_schema_id.to_string(),
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        conn.get_schema_relations(rpc::edge_registry::SchemaId {
+            schema_id: parent_schema_id.to_string(),
+        })
+        .await?
+        .into_inner()
+        .items
+        .into_iter()
+        .map(|entry| {
+            Ok(SchemaRelation {
+                parent_schema_id,
+                relation_id: entry.relation_id.parse()?,
+                child_schema_id: entry.child_schema_id.parse()?,
             })
+        })
+        .collect::<Result<Vec<_>, async_graphql::Error>>()
+    }
+
+    /// List all relations between schemas stored in database
+    #[tracing::instrument(skip(self, context))]
+    async fn all_relations(&self, context: &Context<'_>) -> FieldResult<Vec<SchemaRelation>> {
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        conn.list_relations(rpc::edge_registry::Empty {})
             .await?
             .into_inner()
             .items
             .into_iter()
             .map(|entry| {
                 Ok(SchemaRelation {
-                    parent_schema_id,
                     relation_id: entry.relation_id.parse()?,
+                    parent_schema_id: entry.parent_schema_id.parse()?,
                     child_schema_id: entry.child_schema_id.parse()?,
                 })
             })
             .collect::<Result<Vec<_>, async_graphql::Error>>()
-        }
-        .instrument(span)
-        .await
-    }
-
-    /// List all relations between schemas stored in database
-    async fn all_relations(&self, context: &Context<'_>) -> FieldResult<Vec<SchemaRelation>> {
-        let span = tracing::info_span!("query_all_relations");
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            conn.list_relations(rpc::edge_registry::Empty {})
-                .await?
-                .into_inner()
-                .items
-                .into_iter()
-                .map(|entry| {
-                    Ok(SchemaRelation {
-                        relation_id: entry.relation_id.parse()?,
-                        parent_schema_id: entry.parent_schema_id.parse()?,
-                        child_schema_id: entry.child_schema_id.parse()?,
-                    })
-                })
-                .collect::<Result<Vec<_>, async_graphql::Error>>()
-        }
-        .instrument(span)
-        .await
     }
 
     /// Return all objects that `parent` object is in `relation_id` relation with
+    #[tracing::instrument(skip(self, context))]
     async fn edge(
         &self,
         context: &Context<'_>,
         relation_id: Uuid,
         parent_object_id: Uuid,
     ) -> FieldResult<Vec<Uuid>> {
-        let span = tracing::info_span!("query_edge", ?relation_id, ?parent_object_id);
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            conn.get_edge(rpc::edge_registry::RelationIdQuery {
-                relation_id: relation_id.to_string(),
-                parent_object_id: parent_object_id.to_string(),
-            })
-            .await?
-            .into_inner()
-            .child_object_ids
-            .into_iter()
-            .map(|entry| Ok(entry.parse()?))
-            .collect::<Result<Vec<_>, async_graphql::Error>>()
-        }
-        .instrument(span)
-        .await
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        conn.get_edge(rpc::edge_registry::RelationIdQuery {
+            relation_id: relation_id.to_string(),
+            parent_object_id: parent_object_id.to_string(),
+        })
+        .await?
+        .into_inner()
+        .child_object_ids
+        .into_iter()
+        .map(|entry| Ok(entry.parse()?))
+        .collect::<Result<Vec<_>, async_graphql::Error>>()
     }
 
     /// Return all relations that `parent` object is in
+    #[tracing::instrument(skip(self, context))]
     async fn edges(
         &self,
         context: &Context<'_>,
         parent_object_id: Uuid,
     ) -> FieldResult<Vec<EdgeRelations>> {
-        let span = tracing::info_span!("query_edges", ?parent_object_id);
-        async move {
-            let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
-            conn.get_edges(rpc::edge_registry::ObjectIdQuery {
-                object_id: parent_object_id.to_string(),
+        let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
+        conn.get_edges(rpc::edge_registry::ObjectIdQuery {
+            object_id: parent_object_id.to_string(),
+        })
+        .await?
+        .into_inner()
+        .relations
+        .into_iter()
+        .map(|entry| {
+            Ok(EdgeRelations {
+                relation_id: entry.relation_id.parse()?,
+                parent_object_id: entry.parent_object_id.parse()?,
+                child_object_ids: entry
+                    .child_object_ids
+                    .into_iter()
+                    .map(|s| Ok(s.parse()?))
+                    .collect::<Result<Vec<_>, async_graphql::Error>>()?,
             })
-            .await?
-            .into_inner()
-            .relations
-            .into_iter()
-            .map(|entry| {
-                Ok(EdgeRelations {
-                    relation_id: entry.relation_id.parse()?,
-                    parent_object_id: entry.parent_object_id.parse()?,
-                    child_object_ids: entry
-                        .child_object_ids
-                        .into_iter()
-                        .map(|s| Ok(s.parse()?))
-                        .collect::<Result<Vec<_>, async_graphql::Error>>()?,
-                })
-            })
-            .collect::<Result<Vec<_>, async_graphql::Error>>()
-        }
-        .instrument(span)
-        .await
+        })
+        .collect::<Result<Vec<_>, async_graphql::Error>>()
     }
 
     /// On demand materialized view
+    #[tracing::instrument(skip(self, context))]
     async fn on_demand_view(
         &self,
         context: &Context<'_>,
         view_id: Uuid,
     ) -> FieldResult<MaterializedView> {
-        let span = tracing::info_span!("query_on_demand_view", ?view_id);
-        async move {
-            let mut conn = context.data_unchecked::<ObjectBuilderPool>().get().await?;
-            let materialized = conn
-                .materialize(utils::tracing::grpc::inject_span(ViewId {
-                    view_id: view_id.to_string(),
-                }))
-                .await?
-                .into_inner();
+        let mut conn = context.data_unchecked::<ObjectBuilderPool>().get().await?;
+        let materialized = conn
+            .materialize(utils::tracing::grpc::inject_span(ViewId {
+                view_id: view_id.to_string(),
+            }))
+            .await?
+            .into_inner();
 
-            let rows = materialized
-                .rows
-                .into_iter()
-                .map(|row| {
-                    let fields = row
-                        .fields
-                        .into_iter()
-                        .map(|(field_name, field)| {
-                            let field = serde_json::from_str(&field)?;
-                            Ok((field_name, Json(field)))
-                        })
-                        .collect::<Result<_, async_graphql::Error>>()?;
-
-                    Ok(RowDefinition {
-                        object_id: row.object_id.parse()?,
-                        fields,
+        let rows = materialized
+            .rows
+            .into_iter()
+            .map(|row| {
+                let fields = row
+                    .fields
+                    .into_iter()
+                    .map(|(field_name, field)| {
+                        let field = serde_json::from_str(&field)?;
+                        Ok((field_name, Json(field)))
                     })
+                    .collect::<Result<_, async_graphql::Error>>()?;
+
+                Ok(RowDefinition {
+                    object_id: row.object_id.parse()?,
+                    fields,
                 })
-                .collect::<Result<_, async_graphql::Error>>()?;
-
-            let options = serde_json::from_str(&materialized.options)?;
-
-            Ok(MaterializedView {
-                id: view_id,
-                materializer_options: Json(options),
-                rows,
             })
-        }
-        .instrument(span)
-        .await
+            .collect::<Result<_, async_graphql::Error>>()?;
+
+        let options = serde_json::from_str(&materialized.options)?;
+
+        Ok(MaterializedView {
+            id: view_id,
+            materializer_options: Json(options),
+            rows,
+        })
     }
 }

--- a/crates/api/src/schema/query.rs
+++ b/crates/api/src/schema/query.rs
@@ -50,6 +50,9 @@ impl Schema {
     #[tracing::instrument(skip(self, context), fields(id))]
     async fn definition(&self, context: &Context<'_>, version: String) -> FieldResult<Definition> {
         let id = self.id.to_string();
+        // For unknown reason i couldn't do fields(self.id = ?self.id) even tho documentation says I should
+        // (https://docs.rs/tracing/0.1.25/tracing/attr.instrument.html#examples-2)...
+        // So this is way around it.
         tracing::Span::current().record("id", &id.as_str());
         let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
         let schema_def = conn
@@ -73,6 +76,7 @@ impl Schema {
     async fn definitions(&self, context: &Context<'_>) -> FieldResult<Vec<Definition>> {
         let id = self.id.to_string();
         tracing::Span::current().record("id", &id.as_str());
+
         let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
         let rpc_id = rpc::schema_registry::Id { id: id.clone() };
 
@@ -108,6 +112,7 @@ impl Schema {
     async fn views(&self, context: &Context<'_>) -> FieldResult<Vec<View>> {
         let id = self.id.to_string();
         tracing::Span::current().record("id", &id.as_str());
+
         let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
         let rpc_id = rpc::schema_registry::Id { id: id.clone() };
 


### PR DESCRIPTION
Yay, no more `tracing::span_info!`!

Did four things:
* Enabled tracing for graphQL API (feature flag in dependency lol)
* Removed `tracing::span_info!` and `async move` and `.instrument()` cluttering bullshit
* Added `tracing::instrument` attribute instead.
* Formated code with `rustfmt`