### PR TITLE
fix: Add `with-serde-json-1` feature flag

### DIFF
--- a/crates/materializer-general/Cargo.toml
+++ b/crates/materializer-general/Cargo.toml
@@ -24,5 +24,5 @@ tokio       = { version = "1.5", features = ["rt-multi-thread", "macros", "sync"
 tonic       = "0.4"
 tracing     = "0.1"
 uuid        = "0.8"
-bb8-postgres            = { version = "0.7", features = ["with-uuid-0_8"] }
+bb8-postgres            = { version = "0.7", features = ["with-uuid-0_8", "with-serde_json-1"] }
 tracing-futures         = "0.2"


### PR DESCRIPTION
fixes #453 

Whats worth mentioning - CI didnt catch it because we are running `cargo build --all`. To test it please run `cargo build -p materializer-general`.