### PR TITLE
feat: Use config crate as base for cdl configuration, in place of clap and cli

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -18,7 +18,6 @@ utils       = { path = "../utils" }
 anyhow      = "1.0"
 async-trait = "0.1"
 bb8         = "0.7"
-clap        = "3.0.0-beta.2"
 itertools   = "0.10"
 semver      = { version = "0.11", features = ["serde"] }
 serde       = { version = "1.0", features = ["derive"] }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,7 +1,7 @@
-pub mod config;
 pub mod error;
 pub mod events;
 pub mod schema;
+pub mod settings;
 pub mod types;
 
 use std::convert::Infallible;
@@ -9,23 +9,26 @@ use std::convert::Infallible;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::Schema;
 use async_graphql_warp::{graphql_subscription, Response};
-use clap::Clap;
 use warp::{http::Response as HttpResponse, hyper::header::CONTENT_TYPE, hyper::Method, Filter};
 
 use crate::schema::context::EdgeRegistryConnectionManager;
-use config::Config;
 use schema::context::{
     MQEvents, OnDemandMaterializerConnectionManager, SchemaRegistryConnectionManager,
 };
 use schema::{mutation::MutationRoot, query::QueryRoot, subscription::SubscriptionRoot};
+use settings::Settings;
+use utils::settings::load_settings;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let config = Config::parse();
-    let input_port = config.input_port;
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
+
+    tracing::debug!(?settings, "command-line arguments");
+
+    let input_port = settings.input_port;
 
     let cors = warp::cors()
         .allow_methods(&[Method::POST, Method::GET, Method::OPTIONS])
@@ -34,27 +37,27 @@ async fn main() {
 
     let sr_pool = bb8::Pool::builder()
         .build(SchemaRegistryConnectionManager {
-            address: config.schema_registry_addr.clone(),
+            address: settings.services.schema_registry_url.clone(),
         })
         .await
         .unwrap();
 
     let er_pool = bb8::Pool::builder()
         .build(EdgeRegistryConnectionManager {
-            address: config.edge_registry_addr.clone(),
+            address: settings.services.edge_registry_url.clone(),
         })
         .await
         .unwrap();
 
     let odm_pool = bb8::Pool::builder()
         .build(OnDemandMaterializerConnectionManager {
-            address: config.on_demand_materializer_addr.clone(),
+            address: settings.services.on_demand_materializer_url.clone(),
         })
         .await
         .unwrap();
 
     let schema = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
-        .data(config)
+        .data(settings)
         .data(sr_pool)
         .data(er_pool)
         .data(odm_pool)
@@ -84,4 +87,6 @@ async fn main() {
         .or(warp::path!("graphql").and(graphql_post).with(cors));
 
     utils::tracing::http::serve(routes, ([0, 0, 0, 0], input_port)).await;
+
+    Ok(())
 }

--- a/crates/api/src/schema/context.rs
+++ b/crates/api/src/schema/context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bb8::{Pool, PooledConnection};
 
-use crate::{config::Config, events::EventStream, events::EventSubscriber};
+use crate::{events::EventStream, events::EventSubscriber, settings::Settings};
 use rpc::edge_registry::edge_registry_client::EdgeRegistryClient;
 use rpc::materializer_ondemand::on_demand_materializer_client::OnDemandMaterializerClient;
 use rpc::schema_registry::schema_registry_client::SchemaRegistryClient;
@@ -39,7 +39,7 @@ impl MQEvents {
     pub async fn subscribe_on_communication_method(
         &self,
         topic: &str,
-        config: &Config,
+        settings: &Settings,
     ) -> anyhow::Result<EventStream> {
         tracing::debug!("subscribe on message queue: {}", topic);
 
@@ -51,17 +51,14 @@ impl MQEvents {
             }
             None => {
                 let kafka_events = self.events.clone();
-                let (subscriber, stream) = EventSubscriber::new(
-                    config.communication_method.config()?,
-                    topic,
-                    move |topic| async move {
+                let (subscriber, stream) =
+                    EventSubscriber::new(&settings, topic, move |topic| async move {
                         tracing::warn!("Message queue stream has closed");
                         // Remove topic from hashmap so next time someone ask about this stream,
                         // it will be recreated
                         kafka_events.lock().await.remove(&topic);
-                    },
-                )
-                .await?;
+                    })
+                    .await?;
                 event_map.insert(topic.into(), subscriber);
                 Ok(stream)
             }
@@ -83,7 +80,7 @@ impl bb8::ManageConnection for SchemaRegistryConnectionManager {
     async fn is_valid(&self, conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
         conn.ping(rpc::schema_registry::Empty {})
             .await
-            .map_err(rpc::error::schema_registry_error)?;
+            .map_err(|source| rpc::error::ClientError::QueryError { source })?;
 
         Ok(())
     }
@@ -107,7 +104,7 @@ impl bb8::ManageConnection for EdgeRegistryConnectionManager {
     async fn is_valid(&self, conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
         conn.heartbeat(rpc::edge_registry::Empty {})
             .await
-            .map_err(rpc::error::edge_registry_error)?;
+            .map_err(|source| rpc::error::ClientError::QueryError { source })?;
 
         Ok(())
     }
@@ -131,7 +128,7 @@ impl bb8::ManageConnection for OnDemandMaterializerConnectionManager {
     async fn is_valid(&self, conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
         conn.heartbeat(rpc::materializer_ondemand::Empty {})
             .await
-            .map_err(rpc::error::object_builder_error)?;
+            .map_err(|source| rpc::error::ClientError::QueryError { source })?;
 
         Ok(())
     }

--- a/crates/api/src/schema/query.rs
+++ b/crates/api/src/schema/query.rs
@@ -12,7 +12,7 @@ use crate::types::data::{CdlObject, EdgeRelations, SchemaRelation};
 use crate::types::schema::{Definition, FullSchema};
 use crate::types::view::View;
 use crate::types::view::{MaterializedView, RowDefinition};
-use crate::{config::Config, types::view::OnDemandViewRequest};
+use crate::{settings::Settings, types::view::OnDemandViewRequest};
 use rpc::materializer_ondemand::OnDemandRequest;
 use rpc::schema_registry::types::SchemaType;
 use utils::tracing::http::RequestBuilderTracingExt;
@@ -117,7 +117,10 @@ impl QueryRoot {
         let bytes = client
             .post(&format!(
                 "{}/single/{}",
-                &context.data_unchecked::<Config>().query_router_addr,
+                &context
+                    .data_unchecked::<Settings>()
+                    .services
+                    .query_router_url,
                 object_id
             ))
             .header("SCHEMA_ID", schema_id.to_string())
@@ -149,7 +152,10 @@ impl QueryRoot {
         let values: HashMap<Uuid, serde_json::Value> = client
             .get(&format!(
                 "{}/multiple/{}",
-                &context.data_unchecked::<Config>().query_router_addr,
+                &context
+                    .data_unchecked::<Settings>()
+                    .services
+                    .query_router_url,
                 id_list
             ))
             .header("SCHEMA_ID", schema_id.to_string())
@@ -180,7 +186,10 @@ impl QueryRoot {
         let values: HashMap<Uuid, serde_json::Value> = client
             .get(&format!(
                 "{}/schema",
-                &context.data_unchecked::<Config>().query_router_addr,
+                &context
+                    .data_unchecked::<Settings>()
+                    .services
+                    .query_router_url,
             ))
             .header("SCHEMA_ID", schema_id.to_string())
             .inject_span()

--- a/crates/api/src/schema/utils.rs
+++ b/crates/api/src/schema/utils.rs
@@ -1,19 +1,15 @@
-use anyhow::Context;
-use async_graphql::FieldResult;
-use uuid::Uuid;
-
-use crate::config::{CommunicationMethodConfig, Config};
 use crate::schema::context::SchemaRegistryConn;
 use crate::types::schema::FullSchema;
 use crate::types::view::View;
-use utils::communication::publisher::CommonPublisher;
+use async_graphql::FieldResult;
+use uuid::Uuid;
 
 pub async fn get_view(conn: &mut SchemaRegistryConn, id: Uuid) -> FieldResult<View> {
     tracing::debug!("get view: {:?}", id);
     let view = conn
         .get_view(rpc::schema_registry::Id { id: id.to_string() })
         .await
-        .map_err(rpc::error::schema_registry_error)?
+        .map_err(|source| rpc::error::ClientError::QueryError { source })?
         .into_inner();
 
     View::from_rpc(view)
@@ -24,24 +20,8 @@ pub async fn get_schema(conn: &mut SchemaRegistryConn, id: Uuid) -> FieldResult<
     let schema = conn
         .get_full_schema(rpc::schema_registry::Id { id: id.to_string() })
         .await
-        .map_err(rpc::error::schema_registry_error)?
+        .map_err(|source| rpc::error::ClientError::QueryError { source })?
         .into_inner();
 
     FullSchema::from_rpc(schema)
-}
-
-pub async fn connect_to_cdl_input(config: &Config) -> anyhow::Result<CommonPublisher> {
-    match config.communication_method.config()? {
-        CommunicationMethodConfig::Amqp {
-            connection_string, ..
-        } => CommonPublisher::new_amqp(&connection_string)
-            .await
-            .context("Unable to open RabbitMQ publisher for Ingestion Sink"),
-        CommunicationMethodConfig::Kafka { brokers, .. } => CommonPublisher::new_kafka(&brokers)
-            .await
-            .context("Unable to open Kafka publisher for Ingestion Sink"),
-        CommunicationMethodConfig::Grpc => CommonPublisher::new_grpc("ingestion-sink")
-            .await
-            .context("Unable to create GRPC publisher for Ingestion Sink"),
-    }
 }

--- a/crates/api/src/settings.rs
+++ b/crates/api/src/settings.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+use utils::communication::publisher::CommonPublisher;
+use utils::settings::*;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub communication_method: CommunicationMethod,
+    pub input_port: u16,
+    pub insert_destination: String,
+
+    pub kafka: Option<KafkaSettings>,
+    pub amqp: Option<AmqpSettings>,
+
+    pub services: ServicesSettings,
+
+    pub notification_consumer: Option<NotificationConsumerSettings>,
+
+    pub log: LogSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ServicesSettings {
+    pub schema_registry_url: String,
+    pub edge_registry_url: String,
+    pub on_demand_materializer_url: String,
+    pub query_router_url: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct NotificationConsumerSettings {
+    pub source: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AmqpSettings {
+    pub exchange_url: String,
+    pub tag: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KafkaSettings {
+    pub brokers: String,
+    pub group_id: String,
+}
+
+impl Settings {
+    pub async fn publisher(&self) -> anyhow::Result<CommonPublisher> {
+        match (&self.kafka, &self.amqp, &self.communication_method) {
+            (Some(kafka), _, CommunicationMethod::Kafka) => {
+                Ok(CommonPublisher::new_kafka(&kafka.brokers).await?)
+            }
+            (_, Some(amqp), CommunicationMethod::Amqp) => {
+                Ok(CommonPublisher::new_amqp(&amqp.exchange_url).await?)
+            }
+            (_, _, CommunicationMethod::GRpc) => Ok(CommonPublisher::new_grpc().await?),
+            _ => anyhow::bail!("Unsupported consumer specification"),
+        }
+    }
+}

--- a/crates/cdl-cli/src/main.rs
+++ b/crates/cdl-cli/src/main.rs
@@ -10,7 +10,7 @@ use clap::Clap;
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    ::utils::tracing::init();
+    ::utils::tracing::init(None)?;
 
     match args.action {
         Action::Schema { action } => match action {

--- a/crates/command-service/Cargo.toml
+++ b/crates/command-service/Cargo.toml
@@ -22,7 +22,6 @@ utils       = { path = "../utils" }
 anyhow      = "1.0"
 async-trait = "0.1"
 bb8         = "0.7"
-clap        = "3.0.0-beta.2"
 fnv         = "1.0"
 futures     = "0.3"
 rdkafka     = { version = "0.26", features = ["cmake-build"] }

--- a/crates/command-service/src/communication/config.rs
+++ b/crates/command-service/src/communication/config.rs
@@ -1,5 +1,4 @@
 use std::net::{Ipv4Addr, SocketAddrV4};
-use url::Url;
 
 use utils::{
     communication::{
@@ -25,7 +24,6 @@ pub enum CommunicationConfig {
     },
     Grpc {
         grpc_port: u16,
-        report_endpoint_url: Url,
     },
 }
 

--- a/crates/command-service/src/communication/mod.rs
+++ b/crates/command-service/src/communication/mod.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use tracing::trace;
 use utils::message_types::{BorrowedInsertMessage, OwnedInsertMessage};
 use utils::metrics::*;
-use utils::notification::NotificationSender;
+use utils::notification::NotificationPublisher;
 
 pub mod config;
 pub mod resolution;
 
 pub struct MessageRouter<P: OutputPlugin> {
-    notification_sender: NotificationSender<OwnedInsertMessage>,
+    notification_sender: NotificationPublisher<OwnedInsertMessage>,
     output_plugin: Arc<P>,
 }
 
@@ -24,7 +24,7 @@ impl<P: OutputPlugin> Clone for MessageRouter<P> {
 }
 
 impl<P: OutputPlugin> MessageRouter<P> {
-    pub fn new(report_sender: NotificationSender<OwnedInsertMessage>, output_plugin: P) -> Self {
+    pub fn new(report_sender: NotificationPublisher<OwnedInsertMessage>, output_plugin: P) -> Self {
         Self {
             notification_sender: report_sender,
             output_plugin: Arc::new(output_plugin),

--- a/crates/command-service/src/lib.rs
+++ b/crates/command-service/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod args;
 pub mod communication;
 pub mod input;
 pub mod output;
+pub mod settings;

--- a/crates/command-service/src/main.rs
+++ b/crates/command-service/src/main.rs
@@ -1,97 +1,84 @@
-use clap::Clap;
+use anyhow::bail;
 use command_service::communication::MessageRouter;
 use command_service::input::{Error, Service};
 use command_service::output::{
-    DruidOutputPlugin, OutputArgs, OutputPlugin, PostgresOutputPlugin, VictoriaMetricsOutputPlugin,
+    DruidOutputPlugin, OutputPlugin, PostgresOutputPlugin, VictoriaMetricsOutputPlugin,
 };
-use command_service::{args::Args, communication::config::CommunicationConfig};
+use command_service::settings::{RepositoryKind, Settings};
 use tracing::debug;
-use utils::communication::publisher::CommonPublisher;
+use utils::communication::parallel_consumer::ParallelCommonConsumer;
+use utils::message_types::OwnedInsertMessage;
 use utils::metrics;
-use utils::notification::full_notification_sender::FullNotificationSenderBase;
-use utils::notification::{NotificationSender, NotificationServiceConfig};
+use utils::notification::NotificationPublisher;
+use utils::settings::load_settings;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let args: Args = Args::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    debug!("Environment: {:?}", args);
+    tracing::debug!(?settings, "command-line arguments");
 
-    metrics::serve(args.metrics_port);
+    metrics::serve(&settings.monitoring);
 
-    let communication_config = args.communication_config()?;
+    let consumers = settings.consumers(settings.async_task_limit).await?;
+    let notification_publisher = settings
+        .notifications
+        .publisher(
+            settings.publisher().await?,
+            settings.communication_method.to_string(),
+            "CommandService",
+        )
+        .await;
 
-    match args.output_config {
-        OutputArgs::Postgres(postgres_config) => {
+    match (
+        settings.postgres,
+        settings.victoria_metrics,
+        settings.druid,
+        settings.repository_kind,
+    ) {
+        (Some(postgres), _, _, RepositoryKind::Postgres) => {
             start_services(
-                communication_config,
-                args.notification_config,
-                PostgresOutputPlugin::new(postgres_config).await?,
+                consumers,
+                notification_publisher,
+                PostgresOutputPlugin::new(postgres).await?,
             )
             .await
         }
-        OutputArgs::Druid(druid_config) => {
+        (_, Some(victoria_metrics), _, RepositoryKind::VictoriaMetrics) => {
             start_services(
-                communication_config,
-                args.notification_config,
-                DruidOutputPlugin::new(druid_config).await?,
+                consumers,
+                notification_publisher,
+                VictoriaMetricsOutputPlugin::new(victoria_metrics)?,
             )
             .await
         }
-        OutputArgs::VictoriaMetrics(victoria_metrics_config) => {
-            start_services(
-                communication_config,
-                args.notification_config,
-                VictoriaMetricsOutputPlugin::new(victoria_metrics_config)?,
-            )
-            .await
+        (_, _, Some(druid), RepositoryKind::Druid) => {
+            if let Some(kafka) = settings.kafka {
+                start_services(
+                    consumers,
+                    notification_publisher,
+                    DruidOutputPlugin::new(druid, &kafka.brokers).await?,
+                )
+                .await
+            } else {
+                bail!("Druid setup requires [kafka] section")
+            }
         }
+        _ => bail!("Unsupported consumer specification"),
     }?;
 
     Ok(())
 }
 
 async fn start_services(
-    communication_config: CommunicationConfig,
-    notification_config: NotificationServiceConfig,
+    communication_config: Vec<ParallelCommonConsumer>,
+    notification_publisher: NotificationPublisher<OwnedInsertMessage>,
     output: impl OutputPlugin,
 ) -> Result<(), Error> {
-    let report_service = match notification_config.destination {
-        Some(destination) => {
-            let publisher = match &communication_config {
-                CommunicationConfig::Kafka { brokers, .. } => CommonPublisher::new_kafka(&brokers)
-                    .await
-                    .map_err(Error::ConsumerCreationFailed)?,
-                CommunicationConfig::Amqp {
-                    connection_string, ..
-                } => CommonPublisher::new_amqp(&connection_string)
-                    .await
-                    .map_err(Error::ConsumerCreationFailed)?,
-                CommunicationConfig::Grpc {
-                    report_endpoint_url,
-                    ..
-                } => CommonPublisher::new_rest(report_endpoint_url.clone())
-                    .await
-                    .map_err(Error::ConsumerCreationFailed)?,
-            };
-
-            NotificationSender::Full(
-                FullNotificationSenderBase::new(
-                    publisher,
-                    destination,
-                    output.name().to_string(),
-                    "CommandService",
-                )
-                .await,
-            )
-        }
-        None => NotificationSender::Disabled,
-    };
-
-    let message_router = MessageRouter::new(report_service, output);
+    let message_router = MessageRouter::new(notification_publisher, output);
 
     debug!("Starting command service on a message-queue");
     Service::new(communication_config, message_router)

--- a/crates/command-service/src/output/druid/mod.rs
+++ b/crates/command-service/src/output/druid/mod.rs
@@ -1,6 +1,6 @@
 use crate::communication::resolution::Resolution;
-pub use crate::output::druid::config::DruidOutputConfig;
 use crate::output::OutputPlugin;
+use crate::settings::DruidSettings;
 use anyhow::Context;
 use futures::stream::{self, StreamExt};
 use rdkafka::producer::{FutureProducer, FutureRecord};
@@ -12,8 +12,6 @@ use tracing::error;
 use utils::message_types::BorrowedInsertMessage;
 use utils::metrics::{self, counter};
 use uuid::Uuid;
-
-mod config;
 
 #[derive(Deserialize)]
 struct TimeseriesInputMessage {
@@ -35,14 +33,14 @@ pub struct DruidOutputPlugin {
 }
 
 impl DruidOutputPlugin {
-    pub async fn new(args: DruidOutputConfig) -> anyhow::Result<Self> {
+    pub async fn new(settings: DruidSettings, brokers: &str) -> anyhow::Result<Self> {
         Ok(Self {
             producer: ClientConfig::new()
-                .set("bootstrap.servers", &args.brokers)
+                .set("bootstrap.servers", brokers)
                 .set("message.timeout.ms", "5000")
                 .create()
                 .context("Producer creation")?,
-            topic: args.topic,
+            topic: settings.topic,
         })
     }
 }

--- a/crates/command-service/src/output/mod.rs
+++ b/crates/command-service/src/output/mod.rs
@@ -1,21 +1,12 @@
 use crate::communication::resolution::Resolution;
-pub use crate::output::druid::{DruidOutputConfig, DruidOutputPlugin};
-pub use crate::output::victoria_metrics::config::VictoriaMetricsConfig;
-pub use crate::output::victoria_metrics::VictoriaMetricsOutputPlugin;
-use clap::Clap;
-pub use psql::{PostgresOutputConfig, PostgresOutputPlugin};
+pub use druid::DruidOutputPlugin;
+pub use psql::PostgresOutputPlugin;
 use utils::message_types::BorrowedInsertMessage;
+pub use victoria_metrics::VictoriaMetricsOutputPlugin;
 
 mod druid;
 mod psql;
 mod victoria_metrics;
-
-#[derive(Clone, Debug, Clap)]
-pub enum OutputArgs {
-    Postgres(PostgresOutputConfig),
-    Druid(DruidOutputConfig),
-    VictoriaMetrics(VictoriaMetricsConfig),
-}
 
 #[async_trait::async_trait]
 pub trait OutputPlugin: Send + Sync + 'static {

--- a/crates/command-service/src/output/psql/mod.rs
+++ b/crates/command-service/src/output/psql/mod.rs
@@ -1,20 +1,18 @@
-use std::time;
-
 use crate::communication::resolution::Resolution;
 use crate::output::OutputPlugin;
 use bb8::Pool;
 use bb8_postgres::tokio_postgres::types::Json;
 use bb8_postgres::tokio_postgres::{Config, NoTls};
 use bb8_postgres::PostgresConnectionManager;
-pub use config::PostgresOutputConfig;
 pub use error::Error;
 use serde_json::Value;
+use std::time;
 use tracing::{error, trace};
 use utils::message_types::BorrowedInsertMessage;
 use utils::metrics::{self, counter};
 use utils::psql::validate_schema;
+use utils::settings::PostgresSettings;
 
-pub mod config;
 pub mod error;
 
 pub struct PostgresOutputPlugin {
@@ -23,7 +21,7 @@ pub struct PostgresOutputPlugin {
 }
 
 impl PostgresOutputPlugin {
-    pub async fn new(config: PostgresOutputConfig) -> Result<Self, Error> {
+    pub async fn new(config: PostgresSettings) -> Result<Self, Error> {
         let mut pg_config = Config::new();
         pg_config
             .user(&config.username)

--- a/crates/command-service/src/output/victoria_metrics/mod.rs
+++ b/crates/command-service/src/output/victoria_metrics/mod.rs
@@ -1,5 +1,4 @@
 use crate::communication::resolution::Resolution;
-use crate::output::victoria_metrics::config::VictoriaMetricsConfig;
 use crate::output::OutputPlugin;
 use fnv::FnvHashMap;
 use reqwest::Url;
@@ -12,9 +11,8 @@ use tracing::error;
 use url::ParseError;
 use utils::message_types::BorrowedInsertMessage;
 use utils::metrics::{self, counter};
+use utils::settings::VictoriaMetricsSettings;
 use uuid::Uuid;
-
-pub mod config;
 
 pub struct VictoriaMetricsOutputPlugin {
     client: Client,
@@ -34,7 +32,7 @@ pub enum Error {
 }
 
 impl VictoriaMetricsOutputPlugin {
-    pub fn new(config: VictoriaMetricsConfig) -> Result<VictoriaMetricsOutputPlugin, Error> {
+    pub fn new(config: VictoriaMetricsSettings) -> Result<VictoriaMetricsOutputPlugin, Error> {
         let client = Client::new();
 
         Ok(VictoriaMetricsOutputPlugin {

--- a/crates/command-service/src/settings.rs
+++ b/crates/command-service/src/settings.rs
@@ -1,0 +1,195 @@
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
+use utils::communication::consumer::BasicConsumeOptions;
+use utils::communication::parallel_consumer::{
+    ParallelCommonConsumer, ParallelCommonConsumerConfig,
+};
+use utils::communication::publisher::CommonPublisher;
+use utils::settings::*;
+use utils::task_limiter::TaskLimiter;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub communication_method: CommunicationMethod,
+    pub repository_kind: RepositoryKind,
+
+    #[serde(default = "default_async_task_limit")]
+    pub async_task_limit: usize,
+
+    // Repository settings - based on repository_kind
+    pub postgres: Option<PostgresSettings>,
+    pub victoria_metrics: Option<VictoriaMetricsSettings>,
+    pub druid: Option<DruidSettings>,
+
+    // Communication settings - based on communication_method
+    pub kafka: Option<KafkaSettings>,
+    pub amqp: Option<AmqpSettings>,
+    pub grpc: Option<GRpcSettings>,
+
+    #[serde(default)]
+    pub notifications: NotificationSettings,
+
+    pub listener: ListenerSettings,
+
+    pub monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    pub log: LogSettings,
+}
+
+const fn default_async_task_limit() -> usize {
+    32
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListenerSettings {
+    #[serde(default)]
+    pub ordered_sources: String,
+    #[serde(default)]
+    pub unordered_sources: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryKind {
+    Postgres,
+    VictoriaMetrics,
+    Druid,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DruidSettings {
+    pub topic: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct KafkaSettings {
+    pub brokers: String,
+    pub group_id: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AmqpSettings {
+    pub exchange_url: String,
+    pub tag: String,
+    pub consume_options: Option<BasicConsumeOptions>,
+}
+
+impl ListenerSettings {
+    fn is_empty(&self) -> bool {
+        self.ordered_sources.is_empty() && self.unordered_sources.is_empty()
+    }
+}
+
+impl Settings {
+    pub async fn consumers(
+        &self,
+        task_limit: usize,
+    ) -> anyhow::Result<Vec<ParallelCommonConsumer>> {
+        let task_limiter = TaskLimiter::new(task_limit);
+
+        match (&self.kafka, &self.amqp, &self.grpc) {
+            (Some(kafka), _, _) if self.communication_method == CommunicationMethod::Kafka => {
+                if self.listener.is_empty() {
+                    bail!("Missing list of listener queues")
+                }
+
+                kafka
+                    .parallel_consumers(
+                        self.listener
+                            .ordered_sources
+                            .split(',')
+                            .filter(|s| !s.is_empty()),
+                        self.listener
+                            .unordered_sources
+                            .split(',')
+                            .filter(|s| !s.is_empty()),
+                        task_limiter,
+                    )
+                    .await
+            }
+            (_, Some(amqp), _) if self.communication_method == CommunicationMethod::Amqp => {
+                if self.listener.is_empty() {
+                    bail!("Missing list of listener queues")
+                }
+
+                amqp.parallel_consumers(
+                    self.listener
+                        .ordered_sources
+                        .split(',')
+                        .filter(|s| !s.is_empty()),
+                    self.listener
+                        .unordered_sources
+                        .split(',')
+                        .filter(|s| !s.is_empty()),
+                    task_limiter,
+                )
+                .await
+            }
+            (_, _, Some(grpc)) if self.communication_method == CommunicationMethod::GRpc => {
+                Ok(vec![grpc.parallel_consumer().await?])
+            }
+            _ => anyhow::bail!("Unsupported consumer specification"),
+        }
+    }
+
+    pub async fn publisher(&self) -> anyhow::Result<CommonPublisher> {
+        publisher(
+            self.kafka.as_ref().map(|kafka| kafka.brokers.as_str()),
+            self.amqp.as_ref().map(|amqp| amqp.exchange_url.as_str()),
+            self.grpc.as_ref().map(|_| ()),
+        )
+        .await
+    }
+}
+
+impl KafkaSettings {
+    pub async fn parallel_consumers<'a>(
+        &self,
+        ordered_sources: impl Iterator<Item = &'a str>,
+        unordered_sources: impl Iterator<Item = &'a str>,
+        task_limiter: TaskLimiter,
+    ) -> anyhow::Result<Vec<ParallelCommonConsumer>> {
+        let mut result = Vec::new();
+
+        for topic in ordered_sources.chain(unordered_sources) {
+            result.push(
+                ParallelCommonConsumer::new(ParallelCommonConsumerConfig::Kafka {
+                    brokers: &self.brokers,
+                    group_id: &self.group_id,
+                    topic,
+                    task_limiter: task_limiter.clone(),
+                })
+                .await?,
+            )
+        }
+
+        Ok(result)
+    }
+}
+
+impl AmqpSettings {
+    pub async fn parallel_consumers<'a>(
+        &self,
+        ordered_sources: impl Iterator<Item = &'a str>,
+        unordered_sources: impl Iterator<Item = &'a str>,
+        task_limiter: TaskLimiter,
+    ) -> anyhow::Result<Vec<ParallelCommonConsumer>> {
+        let mut result = Vec::new();
+
+        for queue in ordered_sources.chain(unordered_sources) {
+            result.push(
+                ParallelCommonConsumer::new(ParallelCommonConsumerConfig::Amqp {
+                    connection_string: &self.exchange_url,
+                    consumer_tag: &self.tag,
+                    queue_name: queue,
+                    task_limiter: task_limiter.clone(),
+                    options: self.consume_options,
+                })
+                .await?,
+            )
+        }
+
+        Ok(result)
+    }
+}

--- a/crates/data-router/Cargo.toml
+++ b/crates/data-router/Cargo.toml
@@ -17,7 +17,6 @@ rpc         = { path = "../rpc" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap = "3.0.0-beta.2"
 lru-cache   = "0.1"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"

--- a/crates/data-router/src/main.rs
+++ b/crates/data-router/src/main.rs
@@ -1,23 +1,22 @@
-use std::net::{Ipv4Addr, SocketAddrV4};
-use std::sync::{Arc, Mutex};
-
 use anyhow::Context;
 use async_trait::async_trait;
-use clap::Clap;
 use lru_cache::LruCache;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{debug, error, trace};
+use std::sync::{Arc, Mutex};
+use tracing::{error, trace};
 
 use rpc::schema_registry::Id;
+use utils::settings::{
+    load_settings, AmqpSettings, ConsumerKafkaSettings, GRpcSettings, LogSettings,
+    MonitoringSettings,
+};
 use utils::{
     abort_on_poison,
     communication::{
         get_order_group_id,
         message::CommunicationMessage,
-        parallel_consumer::{
-            ParallelCommonConsumer, ParallelCommonConsumerConfig, ParallelConsumerHandler,
-        },
+        parallel_consumer::{ParallelCommonConsumer, ParallelConsumerHandler},
         publisher::CommonPublisher,
     },
     current_timestamp,
@@ -29,67 +28,96 @@ use utils::{
 };
 use uuid::Uuid;
 
-#[derive(Clap, Deserialize, Debug, Serialize)]
+#[derive(Deserialize, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 enum CommunicationMethod {
     Kafka,
     Amqp,
-    #[clap(alias = "grpc")]
+    #[serde(rename = "grpc")]
     GRpc,
 }
 
-#[derive(Clap, Deserialize, Debug, Serialize)]
-struct Config {
-    /// The method of communication with external services
-    #[clap(long, env, arg_enum, case_insensitive = true)]
-    pub communication_method: CommunicationMethod,
-    /// Address of Kafka brokers
-    #[clap(long, env)]
-    pub kafka_brokers: Option<String>,
-    /// Group ID of the consumer
-    #[clap(long, env)]
-    pub kafka_group_id: Option<String>,
-    /// Connection URL to AMQP Server
-    #[clap(long, env)]
-    pub amqp_connection_string: Option<String>,
-    /// Consumer tag
-    #[clap(long, env)]
-    pub amqp_consumer_tag: Option<String>,
-    /// Kafka topic or AMQP queue
-    #[clap(long, env)]
-    pub input_source: Option<String>,
-    /// Address of schema registry gRPC API
-    #[clap(long, env)]
-    pub schema_registry_addr: String,
-    /// How many entries the cache can hold
-    #[clap(long, env)]
-    pub cache_capacity: usize,
-    /// Max requests handled in parallel
-    #[clap(long, env, default_value = "128")]
-    pub task_limit: usize,
-    /// Port to listen on for Prometheus requests
-    #[clap(default_value = metrics::DEFAULT_PORT, env)]
-    pub metrics_port: u16,
-    /// Port to listen on when communication method is `grpc`
-    #[clap(long, env)]
-    pub grpc_port: Option<u16>,
+#[derive(Deserialize, Debug, Serialize)]
+struct Settings {
+    communication_method: CommunicationMethod,
+    cache_capacity: usize,
+    async_task_limit: usize,
+
+    kafka: Option<ConsumerKafkaSettings>,
+    amqp: Option<AmqpSettings>,
+    grpc: Option<GRpcSettings>,
+
+    monitoring: MonitoringSettings,
+
+    services: ServicesSettings,
+
+    log: LogSettings,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+struct ServicesSettings {
+    schema_registry_url: String,
+}
+
+impl Settings {
+    pub async fn consumer(&self) -> anyhow::Result<ParallelCommonConsumer> {
+        match (
+            &self.kafka,
+            &self.amqp,
+            &self.grpc,
+            &self.communication_method,
+        ) {
+            (Some(kafka), _, _, CommunicationMethod::Kafka) => {
+                kafka
+                    .parallel_consumer(TaskLimiter::new(self.async_task_limit))
+                    .await
+            }
+            (_, Some(amqp), _, CommunicationMethod::Amqp) => {
+                amqp.parallel_consumer(TaskLimiter::new(self.async_task_limit))
+                    .await
+            }
+            (_, _, Some(grpc), CommunicationMethod::GRpc) => grpc.parallel_consumer().await,
+            _ => anyhow::bail!("Unsupported consumer specification"),
+        }
+    }
+
+    pub async fn producer(&self) -> anyhow::Result<CommonPublisher> {
+        Ok(
+            match (
+                &self.kafka,
+                &self.amqp,
+                &self.grpc,
+                &self.communication_method,
+            ) {
+                (Some(kafka), _, _, CommunicationMethod::Kafka) => {
+                    CommonPublisher::new_kafka(&kafka.brokers).await?
+                }
+                (_, Some(amqp), _, CommunicationMethod::Amqp) => {
+                    CommonPublisher::new_amqp(&amqp.exchange_url).await?
+                }
+                (_, _, Some(_), CommunicationMethod::GRpc) => CommonPublisher::new_grpc().await?,
+                _ => anyhow::bail!("Unsupported consumer specification"),
+            },
+        )
+    }
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let config: Config = Config::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    debug!("Environment {:?}", config);
+    tracing::debug!(?settings, "command-line arguments");
 
-    metrics::serve(config.metrics_port);
+    metrics::serve(&settings.monitoring);
 
-    let consumer = new_consumer(&config).await?;
-    let producer = Arc::new(new_producer(&config).await?);
+    let consumer = settings.consumer().await?;
+    let producer = Arc::new(settings.producer().await?);
 
-    let cache = Arc::new(Mutex::new(LruCache::new(config.cache_capacity)));
-    let schema_registry_addr = Arc::new(config.schema_registry_addr);
+    let cache = Arc::new(Mutex::new(LruCache::new(settings.cache_capacity)));
+    let schema_registry_addr = Arc::new(settings.services.schema_registry_url);
 
     let task_queue = Arc::new(ParallelTaskQueue::default());
 
@@ -199,88 +227,6 @@ impl ParallelConsumerHandler for Handler {
 
         Ok(())
     }
-}
-
-async fn new_producer(config: &Config) -> anyhow::Result<CommonPublisher> {
-    Ok(match config.communication_method {
-        CommunicationMethod::Kafka => {
-            let brokers = config
-                .kafka_brokers
-                .as_ref()
-                .context("kafka brokers were not specified")?;
-            CommonPublisher::new_kafka(brokers).await?
-        }
-        CommunicationMethod::Amqp => {
-            let connection_string = config
-                .amqp_connection_string
-                .as_ref()
-                .context("amqp connection string was not specified")?;
-            CommonPublisher::new_amqp(connection_string).await?
-        }
-        CommunicationMethod::GRpc => CommonPublisher::new_grpc("command_service").await?,
-    })
-}
-
-async fn new_consumer(config: &Config) -> anyhow::Result<ParallelCommonConsumer> {
-    let config = match config.communication_method {
-        CommunicationMethod::Kafka => {
-            let topic = config
-                .input_source
-                .as_ref()
-                .context("kafka topic was not specified")?;
-            let brokers = config
-                .kafka_brokers
-                .as_ref()
-                .context("kafka brokers were not specified")?;
-            let group_id = config
-                .kafka_group_id
-                .as_ref()
-                .context("kafka group was not specified")?;
-
-            debug!("Initializing Kafka consumer");
-
-            ParallelCommonConsumerConfig::Kafka {
-                brokers: &brokers,
-                group_id: &group_id,
-                task_limiter: TaskLimiter::new(config.task_limit),
-                topic,
-            }
-        }
-        CommunicationMethod::Amqp => {
-            let queue_name = config
-                .input_source
-                .as_ref()
-                .context("amqp queue name was not specified")?;
-            let connection_string = config
-                .amqp_connection_string
-                .as_ref()
-                .context("amqp connection string was not specified")?;
-            let consumer_tag = config
-                .amqp_consumer_tag
-                .as_ref()
-                .context("amqp consumer tag was not specified")?;
-
-            debug!("Initializing Amqp consumer");
-
-            ParallelCommonConsumerConfig::Amqp {
-                connection_string: &connection_string,
-                task_limiter: TaskLimiter::new(config.task_limit),
-                consumer_tag: &consumer_tag,
-                queue_name,
-                options: None,
-            }
-        }
-        CommunicationMethod::GRpc => {
-            let port = config
-                .grpc_port
-                .clone()
-                .context("grpc port was not specified")?;
-
-            let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port);
-            ParallelCommonConsumerConfig::Grpc { addr }
-        }
-    };
-    Ok(ParallelCommonConsumer::new(config).await?)
 }
 
 #[tracing::instrument(skip(producer))]

--- a/crates/db-shrinker-postgres/src/main.rs
+++ b/crates/db-shrinker-postgres/src/main.rs
@@ -27,7 +27,7 @@ struct Opts {
 fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
 
-    utils::tracing::init();
+    utils::tracing::init(None)?;
 
     info!("Running shrinker on PSQL with {:?}", opts);
 

--- a/crates/edge-registry/Cargo.toml
+++ b/crates/edge-registry/Cargo.toml
@@ -21,7 +21,6 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap        = "3.0.0-beta.2"
 futures     = "0.3"
 itertools   = "0.10"
 serde       = { version = "1.0", features = ["derive"] }

--- a/crates/edge-registry/src/main.rs
+++ b/crates/edge-registry/src/main.rs
@@ -1,81 +1,72 @@
-use clap::Clap;
-use edge_registry::args::{ConsumerMethod, RegistryConfig};
+use edge_registry::settings::Settings;
 use edge_registry::EdgeRegistryImpl;
 use rpc::edge_registry::edge_registry_server::EdgeRegistryServer;
 use std::process;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::transport::Server;
-use tracing::{debug, error, info};
-use utils::communication::consumer::CommonConsumer;
-use utils::communication::publisher::CommonPublisher;
-use utils::notification::full_notification_sender::FullNotificationSenderBase;
-use utils::notification::NotificationSender;
+use tracing::{error, info};
+use utils::settings::{load_settings, CommunicationMethod};
 use utils::{metrics, status_endpoints};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let config: RegistryConfig = RegistryConfig::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    debug!("Environment: {:?}", config);
+    tracing::debug!(?settings, "command-line arguments");
 
-    status_endpoints::serve(config.status_port);
-    metrics::serve(config.metrics_port);
+    status_endpoints::serve(&settings.monitoring);
+    metrics::serve(&settings.monitoring);
 
-    let notification_sender = match &config.notification_config.destination {
-        Some(destination) => {
-            let publisher = match config.consumer_config.consumer_method {
-                ConsumerMethod::Kafka => {
-                    CommonPublisher::new_kafka(&config.consumer_config.consumer_host).await?
-                }
-                ConsumerMethod::Amqp => {
-                    CommonPublisher::new_amqp(&config.consumer_config.consumer_host).await?
-                }
-            };
+    let notification_publisher = settings
+        .notifications
+        .publisher(
+            settings.publisher().await?,
+            settings.communication_method.to_string(),
+            "EdgeRegistry",
+        )
+        .await;
 
-            NotificationSender::Full(
-                FullNotificationSenderBase::new(
-                    publisher,
-                    destination.clone(),
-                    "Base".to_string(),
-                    "EdgeRegistry",
-                )
-                .await,
-            )
+    let registry = EdgeRegistryImpl::new(
+        &settings.postgres,
+        Arc::new(Mutex::new(notification_publisher)),
+    )
+    .await?;
+    let consumer = match (settings.kafka, settings.amqp) {
+        (Some(kafka), _) if settings.communication_method == CommunicationMethod::Kafka => {
+            Some(kafka.consumer().await?)
         }
-        None => NotificationSender::Disabled,
+        (_, Some(amqp)) if settings.communication_method == CommunicationMethod::Amqp => {
+            Some(amqp.consumer().await?)
+        }
+        _ => None, // Supported by default, we can skip
     };
 
-    let notification_sender = Arc::new(Mutex::new(notification_sender));
-
-    let registry = EdgeRegistryImpl::new(&config, notification_sender).await?;
-
-    let consumer = CommonConsumer::new((&config.consumer_config).into()).await?;
-
-    let handler = registry.clone();
-    tokio::spawn(async {
-        info!("Listening for messages via MQ");
-        match consumer.run(handler).await {
-            Ok(_) => {
-                error!("MQ consumer finished work"); // If this happens it means that there's problem with Kafka or AMQP connection
+    if let Some(consumer) = consumer {
+        let handler = registry.clone();
+        tokio::spawn(async {
+            info!("Listening for messages via MQ");
+            match consumer.run(handler).await {
+                Ok(_) => {
+                    error!("MQ consumer finished work"); // If this happens it means that there's problem with Kafka or AMQP connection
+                }
+                Err(err) => {
+                    error!("MQ consumer returned with error: {:?}", err);
+                }
             }
-            Err(err) => {
-                error!("MQ consumer returned with error: {:?}", err);
-            }
-        }
-        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-        process::abort();
-    });
+            tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            process::abort();
+        });
+    }
 
     status_endpoints::mark_as_started();
     info!("Starting a grpc server");
     Server::builder()
-        .trace_fn(utils::tracing::grpc::trace_fn)
         .add_service(EdgeRegistryServer::new(registry))
-        .serve(([0, 0, 0, 0], config.rpc_port).into())
+        .serve(([0, 0, 0, 0], settings.input_port).into())
         .await?;
 
     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;

--- a/crates/edge-registry/src/settings.rs
+++ b/crates/edge-registry/src/settings.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+use utils::communication::publisher::CommonPublisher;
+use utils::settings::*;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub communication_method: CommunicationMethod,
+
+    pub postgres: PostgresSettings,
+    pub input_port: u16,
+
+    pub kafka: Option<ConsumerKafkaSettings>,
+    pub amqp: Option<AmqpSettings>,
+
+    #[serde(default)]
+    pub notifications: NotificationSettings,
+
+    pub monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    pub log: LogSettings,
+}
+
+impl Settings {
+    pub async fn publisher(&self) -> anyhow::Result<CommonPublisher> {
+        publisher(
+            self.kafka.as_ref().map(|kafka| kafka.brokers.as_str()),
+            self.amqp.as_ref().map(|amqp| amqp.exchange_url.as_str()),
+            None,
+        )
+        .await
+    }
+}

--- a/crates/materializer-general/Cargo.toml
+++ b/crates/materializer-general/Cargo.toml
@@ -15,7 +15,6 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap        = "3.0.0-beta.2"
 futures     = "0.3"
 itertools   = "0.10"
 serde       = { version = "1.0", features = ["derive"] }

--- a/crates/materializer-general/src/lib.rs
+++ b/crates/materializer-general/src/lib.rs
@@ -1,24 +1,20 @@
-pub mod args;
 mod plugins;
+pub mod settings;
 
-use crate::args::MaterializerArgs;
 use plugins::{MaterializerPlugin, PostgresMaterializer};
 use rpc::materializer_general::MaterializedView;
 use rpc::materializer_general::{general_materializer_server::GeneralMaterializer, Empty, Options};
+use utils::settings::PostgresSettings;
 
 pub struct MaterializerImpl {
     materializer: std::sync::Arc<dyn MaterializerPlugin>,
 }
 
 impl MaterializerImpl {
-    pub async fn new(args: &MaterializerArgs) -> anyhow::Result<Self> {
-        let materializer = match args {
-            MaterializerArgs::Postgres(ref args) => {
-                std::sync::Arc::new(PostgresMaterializer::new(args).await?)
-            }
-        };
-
-        Ok(Self { materializer })
+    pub async fn new(args: PostgresSettings) -> anyhow::Result<Self> {
+        Ok(Self {
+            materializer: std::sync::Arc::new(PostgresMaterializer::new(&args).await?),
+        })
     }
 }
 

--- a/crates/materializer-general/src/main.rs
+++ b/crates/materializer-general/src/main.rs
@@ -1,28 +1,28 @@
-use clap::Clap;
-use materializer_general::{args::Args, MaterializerImpl};
+use materializer_general::{settings::Settings, MaterializerImpl};
 use rpc::materializer_general::general_materializer_server::GeneralMaterializerServer;
 use tonic::transport::Server;
+use utils::settings::load_settings;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let args: Args = Args::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    tracing::debug!(?args, "command-line arguments");
+    tracing::debug!(?settings, "command-line arguments");
 
-    utils::status_endpoints::serve(args.status_port);
-    utils::metrics::serve(args.metrics_port);
+    utils::status_endpoints::serve(&settings.monitoring);
+    utils::metrics::serve(&settings.monitoring);
 
-    let materializer = MaterializerImpl::new(&args.materializer).await?;
+    let materializer = MaterializerImpl::new(settings.postgres).await?;
 
     utils::status_endpoints::mark_as_started();
 
     Server::builder()
         .trace_fn(utils::tracing::grpc::trace_fn)
         .add_service(GeneralMaterializerServer::new(materializer))
-        .serve(([0, 0, 0, 0], args.input_port).into())
+        .serve(([0, 0, 0, 0], settings.input_port).into())
         .await?;
 
     Ok(())

--- a/crates/materializer-general/src/plugins/postgres.rs
+++ b/crates/materializer-general/src/plugins/postgres.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, convert::TryFrom, convert::TryInto};
 
 use super::MaterializerPlugin;
-use crate::args::PostgresMaterializerArgs;
 use bb8_postgres::tokio_postgres::{types::Type, Config, NoTls};
 use bb8_postgres::{bb8, PostgresConnectionManager};
 use bb8_postgres::{
@@ -14,6 +13,7 @@ use rpc::materializer_general::MaterializedView;
 use serde::Deserialize;
 use serde_json::Value;
 use utils::metrics::{self, counter};
+use utils::settings::PostgresSettings;
 use uuid::Uuid;
 
 pub struct PostgresMaterializer {
@@ -183,14 +183,14 @@ impl PostgresMaterializer {
         }
     }
 
-    pub async fn new(args: &PostgresMaterializerArgs) -> anyhow::Result<Self> {
+    pub async fn new(args: &PostgresSettings) -> anyhow::Result<Self> {
         let mut pg_config = Config::new();
         pg_config
-            .user(&args.postgres_username)
-            .password(&args.postgres_password)
-            .host(&args.postgres_host)
-            .port(args.postgres_port)
-            .dbname(&args.postgres_dbname);
+            .user(&args.username)
+            .password(&args.password)
+            .host(&args.host)
+            .port(args.port)
+            .dbname(&args.dbname);
 
         let manager = PostgresConnectionManager::new(pg_config, NoTls);
         let pool = bb8::Pool::builder()
@@ -201,7 +201,7 @@ impl PostgresMaterializer {
 
         Ok(Self {
             pool,
-            schema: args.postgres_schema.clone(),
+            schema: args.schema.clone(),
         })
     }
 }

--- a/crates/materializer-general/src/settings.rs
+++ b/crates/materializer-general/src/settings.rs
@@ -1,0 +1,13 @@
+use serde::Deserialize;
+use utils::settings::{LogSettings, MonitoringSettings, PostgresSettings};
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub input_port: u16,
+
+    pub postgres: PostgresSettings,
+
+    pub monitoring: MonitoringSettings,
+
+    pub log: LogSettings,
+}

--- a/crates/materializer-ondemand/Cargo.toml
+++ b/crates/materializer-ondemand/Cargo.toml
@@ -13,7 +13,6 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap        = "3.0.0-beta.2"
 futures     = "0.3"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"

--- a/crates/materializer-ondemand/src/lib.rs
+++ b/crates/materializer-ondemand/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod args;
+pub mod settings;
 
 use std::pin::Pin;
 
@@ -14,9 +14,9 @@ pub struct MaterializerImpl {
 }
 
 impl MaterializerImpl {
-    pub async fn new(args: &args::Args) -> anyhow::Result<Self> {
+    pub async fn new(object_builder_addr: &str) -> anyhow::Result<Self> {
         Ok(Self {
-            object_builder_addr: args.object_builder_addr.clone(),
+            object_builder_addr: object_builder_addr.to_string(),
         })
     }
 }

--- a/crates/materializer-ondemand/src/main.rs
+++ b/crates/materializer-ondemand/src/main.rs
@@ -1,28 +1,28 @@
-use clap::Clap;
-use materializer_ondemand::{args::Args, MaterializerImpl};
+use materializer_ondemand::{settings::Settings, MaterializerImpl};
 use rpc::materializer_ondemand::on_demand_materializer_server::OnDemandMaterializerServer;
 use tonic::transport::Server;
+use utils::settings::load_settings;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let args: Args = Args::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    tracing::debug!(?args, "command-line arguments");
+    tracing::debug!(?settings, "command-line arguments");
 
-    utils::status_endpoints::serve(args.status_port);
-    utils::metrics::serve(args.metrics_port);
+    utils::status_endpoints::serve(&settings.monitoring);
+    utils::metrics::serve(&settings.monitoring);
 
-    let materializer = MaterializerImpl::new(&args).await?;
+    let materializer = MaterializerImpl::new(&settings.services.object_builder_url).await?;
 
     utils::status_endpoints::mark_as_started();
 
     Server::builder()
         .trace_fn(utils::tracing::grpc::trace_fn)
         .add_service(OnDemandMaterializerServer::new(materializer))
-        .serve(([0, 0, 0, 0], args.input_port).into())
+        .serve(([0, 0, 0, 0], settings.input_port).into())
         .await?;
 
     Ok(())

--- a/crates/materializer-ondemand/src/settings.rs
+++ b/crates/materializer-ondemand/src/settings.rs
@@ -1,0 +1,18 @@
+use serde::Deserialize;
+use utils::settings::{LogSettings, MonitoringSettings};
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub input_port: u16,
+
+    pub services: ServicesSettings,
+
+    pub monitoring: MonitoringSettings,
+
+    pub log: LogSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ServicesSettings {
+    pub object_builder_url: String,
+}

--- a/crates/object-builder/Cargo.toml
+++ b/crates/object-builder/Cargo.toml
@@ -20,7 +20,6 @@ utils       = { path = "../utils" }
 anyhow      = "1.0"
 async-trait = "0.1"
 bb8         = "0.7"
-clap        = "3.0.0-beta.2"
 futures     = "0.3"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"

--- a/crates/object-builder/src/lib.rs
+++ b/crates/object-builder/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::args::Args;
 use anyhow::Context;
 use async_trait::async_trait;
 use bb8::{Pool, PooledConnection};
@@ -19,7 +18,7 @@ use utils::{
 };
 use uuid::Uuid;
 
-pub mod args;
+pub mod settings;
 
 #[derive(Clone)]
 pub struct ObjectBuilderImpl {
@@ -58,7 +57,7 @@ impl bb8::ManageConnection for SchemaRegistryConnectionManager {
     async fn is_valid(&self, conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
         conn.ping(rpc::schema_registry::Empty {})
             .await
-            .map_err(rpc::error::schema_registry_error)?;
+            .map_err(|source| rpc::error::ClientError::QueryError { source })?;
 
         Ok(())
     }
@@ -84,15 +83,13 @@ struct RowDefinition {
 }
 
 impl ObjectBuilderImpl {
-    pub async fn new(args: &Args) -> anyhow::Result<Self> {
+    pub async fn new(schema_registry_addr: &str, chunk_capacity: usize) -> anyhow::Result<Self> {
         let pool = Pool::builder()
             .build(SchemaRegistryConnectionManager {
-                address: args.schema_registry_addr.clone(),
+                address: schema_registry_addr.to_string(),
             })
             .await
             .unwrap();
-
-        let chunk_capacity = args.chunk_capacity;
 
         Ok(Self {
             pool,

--- a/crates/object-builder/src/main.rs
+++ b/crates/object-builder/src/main.rs
@@ -1,49 +1,50 @@
-use clap::Clap;
-use object_builder::{args::Args, ObjectBuilderImpl};
+use object_builder::{settings::Settings, ObjectBuilderImpl};
 use rpc::object_builder::object_builder_server::ObjectBuilderServer;
 use tonic::transport::Server;
-use utils::communication::consumer::CommonConsumer;
+use utils::settings::load_settings;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let args: Args = Args::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    tracing::debug!(?args, "command-line arguments");
+    tracing::debug!(?settings, "command-line arguments");
 
-    utils::status_endpoints::serve(args.status_port);
-    utils::metrics::serve(args.metrics_port);
+    utils::status_endpoints::serve(&settings.monitoring);
+    utils::metrics::serve(&settings.monitoring);
 
-    let object_builder = ObjectBuilderImpl::new(&args).await?;
-    if let Some(consumer_config) = args.consumer_config()? {
-        let consumer = CommonConsumer::new(consumer_config).await?;
-        let handler = object_builder.clone();
-        tokio::spawn(async {
-            tracing::info!("Listening for messages via MQ");
+    let object_builder = ObjectBuilderImpl::new(
+        &settings.services.schema_registry_url,
+        settings.chunk_capacity,
+    )
+    .await?;
+    let consumer = settings.consumer().await?;
+    let handler = object_builder.clone();
+    tokio::spawn(async {
+        tracing::info!("Listening for messages via MQ");
 
-            match consumer.run(handler).await {
-                Ok(_) => {
-                    tracing::error!("MQ consumer finished work");
-                }
-                Err(err) => {
-                    tracing::error!("MQ consumer returned with error: {:?}", err);
-                }
+        match consumer.run(handler).await {
+            Ok(_) => {
+                tracing::error!("MQ consumer finished work");
             }
+            Err(err) => {
+                tracing::error!("MQ consumer returned with error: {:?}", err);
+            }
+        }
 
-            tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
-            std::process::abort();
-        });
-    }
+        std::process::abort();
+    });
 
     utils::status_endpoints::mark_as_started();
 
     Server::builder()
         .trace_fn(utils::tracing::grpc::trace_fn)
         .add_service(ObjectBuilderServer::new(object_builder))
-        .serve(([0, 0, 0, 0], args.input_port).into())
+        .serve(([0, 0, 0, 0], settings.input_port).into())
         .await?;
 
     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;

--- a/crates/object-builder/src/settings.rs
+++ b/crates/object-builder/src/settings.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+use utils::communication::consumer::{CommonConsumer, CommonConsumerConfig};
+use utils::settings::*;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub communication_method: CommunicationMethod,
+    pub input_port: u16,
+    pub chunk_capacity: usize,
+
+    pub kafka: Option<ConsumerKafkaSettings>,
+    pub amqp: Option<AmqpSettings>,
+
+    pub services: ServicesSettings,
+
+    pub monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    pub log: LogSettings,
+}
+
+impl Settings {
+    pub async fn consumer(&self) -> anyhow::Result<CommonConsumer> {
+        match (&self.kafka, &self.amqp, &self.communication_method) {
+            (Some(kafka), _, CommunicationMethod::Kafka) => {
+                Ok(CommonConsumer::new(CommonConsumerConfig::Kafka {
+                    brokers: &kafka.brokers,
+                    group_id: &kafka.group_id,
+                    topic: &kafka.ingest_topic,
+                })
+                .await?)
+            }
+            (_, Some(amqp), CommunicationMethod::Amqp) => {
+                Ok(CommonConsumer::new(CommonConsumerConfig::Amqp {
+                    connection_string: &amqp.exchange_url,
+                    consumer_tag: &amqp.tag,
+                    queue_name: &amqp.ingest_queue,
+                    options: amqp.consume_options,
+                })
+                .await?)
+            }
+            _ => anyhow::bail!("Unsupported consumer specification"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ServicesSettings {
+    pub schema_registry_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunicationMethod {
+    Kafka,
+    Amqp,
+    #[serde(other)]
+    Other,
+}

--- a/crates/partial-update-engine/Cargo.toml
+++ b/crates/partial-update-engine/Cargo.toml
@@ -17,7 +17,6 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap        = "3.0.0-beta.2"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 tokio       = { version = "1.5", features = ["macros"] }

--- a/crates/partial-update-engine/src/main.rs
+++ b/crates/partial-update-engine/src/main.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use clap::Clap;
 use rdkafka::{
     consumer::{CommitMode, DefaultConsumerContext, StreamConsumer},
     message::{BorrowedMessage, OwnedHeaders},
@@ -14,36 +13,38 @@ use rdkafka::{
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
-use tracing::{debug, trace, Instrument};
+use tracing::{trace, Instrument};
+use utils::settings::*;
 use utils::{
     metrics::{self},
     types::materialization,
 };
 use uuid::Uuid;
 
-#[derive(Clap, Deserialize, Debug, Serialize)]
-struct Config {
-    /// Address of Kafka brokers
-    #[clap(long, env)]
-    pub kafka_brokers: String,
-    /// Group ID of the consumer
-    #[clap(long, env)]
-    pub kafka_group_id: String,
-    /// Kafka topic for notifications
-    #[clap(long, env)]
-    pub notification_topic: String,
-    /// Kafka topic for object builder input
-    #[clap(long, env)]
-    pub object_builder_topic: String,
-    /// Address of schema registry gRPC API
-    #[clap(long, env)]
-    pub schema_registry_addr: String,
-    /// Port to listen on for Prometheus requests
-    #[clap(default_value = metrics::DEFAULT_PORT, env)]
-    pub metrics_port: u16,
-    /// Duration of sleep phase in seconds
-    #[clap(long, env)]
-    pub sleep_phase_length: u64,
+#[derive(Deserialize, Debug, Serialize)]
+struct Settings {
+    communication_method: CommunicationMethod,
+    sleep_phase_length: u64,
+
+    kafka: PublisherKafkaSettings,
+    notification_consumer: NotificationConsumerSettings,
+    services: ServicesSettings,
+
+    monitoring: MonitoringSettings,
+
+    log: LogSettings,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+struct NotificationConsumerSettings {
+    #[serde(flatten)]
+    pub kafka: ConsumerKafkaSettings,
+    pub source: String,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+struct ServicesSettings {
+    pub schema_registry_url: String,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Hash)]
@@ -62,28 +63,31 @@ struct CommandServiceNotification {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let config: Config = Config::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    debug!("Environment {:?}", config);
+    tracing::debug!(?settings, "command-line arguments");
 
-    metrics::serve(config.metrics_port);
+    metrics::serve(&settings.monitoring);
 
     let consumer: StreamConsumer<DefaultConsumerContext> = ClientConfig::new()
-        .set("group.id", &config.kafka_group_id)
-        .set("bootstrap.servers", &config.kafka_brokers)
+        .set("group.id", &settings.notification_consumer.kafka.group_id)
+        .set(
+            "bootstrap.servers",
+            &settings.notification_consumer.kafka.brokers,
+        )
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")
         .create()
         .context("Consumer creation failed")?;
-    let topics = [config.notification_topic.as_str()];
+    let topics = [settings.notification_consumer.source.as_str()];
 
     rdkafka::consumer::Consumer::subscribe(&consumer, &topics)
         .context("Can't subscribe to specified topics")?;
 
     let producer = ClientConfig::new()
-        .set("bootstrap.servers", &config.kafka_brokers)
+        .set("bootstrap.servers", &settings.kafka.brokers)
         .set("message.timeout.ms", "5000")
         .set("acks", "all")
         .set("compression.type", "none")
@@ -102,21 +106,29 @@ async fn main() -> anyhow::Result<()> {
                     offsets.insert(partition, offset);
                 }
                 None => {
-                    process_changes(&producer, &config, &mut changes).await?;
-                    acknowledge_messages(&mut offsets, &consumer, &config.notification_topic)
-                        .await?;
+                    process_changes(&producer, &settings, &mut changes).await?;
+                    acknowledge_messages(
+                        &mut offsets,
+                        &consumer,
+                        &settings.notification_consumer.source,
+                    )
+                    .await?;
                     break;
                 }
             },
             Err(_) => {
                 trace!("Timeout");
                 if !changes.is_empty() {
-                    process_changes(&producer, &config, &mut changes).await?;
-                    acknowledge_messages(&mut offsets, &consumer, &config.notification_topic)
-                        .await?;
+                    process_changes(&producer, &settings, &mut changes).await?;
+                    acknowledge_messages(
+                        &mut offsets,
+                        &consumer,
+                        &settings.notification_consumer.source,
+                    )
+                    .await?;
                 }
                 let sleep_phase = tracing::info_span!("Sleep phase");
-                sleep(Duration::from_secs(config.sleep_phase_length))
+                sleep(Duration::from_secs(settings.sleep_phase_length))
                     .instrument(sleep_phase)
                     .await;
             }
@@ -146,14 +158,15 @@ fn new_notification(
     Ok((partition, offset))
 }
 
-#[tracing::instrument(skip(producer, config))]
+#[tracing::instrument(skip(producer, settings))]
 async fn process_changes(
     producer: &FutureProducer,
-    config: &Config,
+    settings: &Settings,
     changes: &mut HashSet<PartialNotification>,
 ) -> Result<()> {
     trace!("processing changes {:#?}", changes);
-    let mut client = rpc::schema_registry::connect(config.schema_registry_addr.to_owned()).await?;
+    let mut client =
+        rpc::schema_registry::connect(settings.services.schema_registry_url.to_owned()).await?;
     let mut schema_cache: HashMap<Uuid, Vec<Uuid>> // (Schema_ID, Vec<View_ID>)
         = Default::default();
 
@@ -205,7 +218,7 @@ async fn process_changes(
         let payload = serde_json::to_string(&request)?;
         producer
             .send(
-                FutureRecord::to(config.object_builder_topic.as_str())
+                FutureRecord::to(settings.kafka.egest_topic.as_str())
                     .payload(payload.as_str())
                     .key(&request.view_id.to_string())
                     .headers(utils::tracing::kafka::inject_span(OwnedHeaders::new())),

--- a/crates/query-router/Cargo.toml
+++ b/crates/query-router/Cargo.toml
@@ -16,7 +16,6 @@ utils       = { path = "../utils" }
 
 # Crates.io
 anyhow      = "1.0"
-clap        = "3.0.0-beta.2"
 lru-cache   = "0.1"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"

--- a/crates/query-router/src/cache.rs
+++ b/crates/query-router/src/cache.rs
@@ -39,12 +39,7 @@ impl SchemaRegistryCache {
                 id: schema_id.to_string(),
             })
             .await
-            .map_err(|err| {
-                Error::ClientError(ClientError::QueryError {
-                    service: "schema registry",
-                    source: err,
-                })
-            })?
+            .map_err(|err| Error::ClientError(ClientError::QueryError { source: err }))?
             .into_inner();
 
         let result = (

--- a/crates/query-router/src/main.rs
+++ b/crates/query-router/src/main.rs
@@ -1,44 +1,49 @@
 use std::sync::Arc;
 
-use clap::Clap;
 use uuid::Uuid;
 use warp::Filter;
 
 use cache::SchemaRegistryCache;
+use serde::Deserialize;
 use utils::metrics;
+use utils::settings::{load_settings, LogSettings, MonitoringSettings};
 
 pub mod cache;
 pub mod error;
 pub mod handler;
 
-#[derive(Clap)]
-struct Config {
-    /// Address of schema registry gRPC API
-    #[clap(long, env = "SCHEMA_REGISTRY_ADDR")]
-    schema_registry_addr: String,
-    /// How many entries the cache can hold
-    #[clap(long, env = "CACHE_CAPACITY")]
+#[derive(Debug, Deserialize)]
+struct Settings {
     cache_capacity: usize,
-    /// Port to listen on
-    #[clap(long, env = "INPUT_PORT")]
     input_port: u16,
-    /// Port to listen on for Prometheus requests
-    #[clap(default_value = metrics::DEFAULT_PORT, env)]
-    pub metrics_port: u16,
+
+    services: ServicesSettings,
+
+    monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    log: LogSettings,
+}
+
+#[derive(Debug, Deserialize)]
+struct ServicesSettings {
+    schema_registry_url: String,
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let config = Config::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    metrics::serve(config.metrics_port);
+    tracing::debug!(?settings, "command-line arguments");
+
+    metrics::serve(&settings.monitoring);
 
     let schema_registry_cache = Arc::new(SchemaRegistryCache::new(
-        config.schema_registry_addr,
-        config.cache_capacity,
+        settings.services.schema_registry_url,
+        settings.cache_capacity,
     ));
 
     let cache_filter = warp::any().map(move || schema_registry_cache.clone());
@@ -71,5 +76,7 @@ async fn main() {
         .and(single_route.or(raw_route))
         .or(warp::get().and(multiple_route.or(schema_route)));
 
-    utils::tracing::http::serve(routes, ([0, 0, 0, 0], config.input_port)).await;
+    utils::tracing::http::serve(routes, ([0, 0, 0, 0], settings.input_port)).await;
+
+    Ok(())
 }

--- a/crates/query-service-ts/Cargo.toml
+++ b/crates/query-service-ts/Cargo.toml
@@ -21,7 +21,6 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 bb8         = "0.7"
-clap        = "3.0.0-beta.2"
 reqwest     = { version = "0.11", features = ["json"] }
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"

--- a/crates/query-service-ts/src/main.rs
+++ b/crates/query-service-ts/src/main.rs
@@ -1,26 +1,32 @@
 use anyhow::Context;
-use clap::Clap;
-use query_service_ts::druid::{DruidConfig, DruidQuery};
-use query_service_ts::victoria::{VictoriaConfig, VictoriaQuery};
+use query_service_ts::druid::{DruidQuery, DruidSettings};
+use query_service_ts::victoria::VictoriaQuery;
 use rpc::query_service_ts::query_service_ts_server::{QueryServiceTs, QueryServiceTsServer};
+use serde::Deserialize;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use tonic::transport::Server;
 use utils::metrics;
+use utils::settings::*;
 
-#[derive(Clap)]
-pub struct Config {
-    #[clap(subcommand)]
-    pub inner: ConfigType,
-    #[clap(long, env = "INPUT_PORT")]
-    pub input_port: u16,
-    #[clap(default_value = metrics::DEFAULT_PORT, env)]
-    pub metrics_port: u16,
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    repository_kind: RepositoryKind,
+    input_port: u16,
+
+    druid: Option<DruidSettings>,
+    victoria_metrics: Option<VictoriaMetricsSettings>,
+
+    monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    log: LogSettings,
 }
 
-#[derive(Clap)]
-pub enum ConfigType {
-    Victoria(VictoriaConfig),
-    Druid(DruidConfig),
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryKind {
+    VictoriaMetrics,
+    Druid,
 }
 
 //Could be extracted to utils, dunno how without schema
@@ -39,20 +45,27 @@ async fn spawn_server<Q: QueryServiceTs>(service: Q, port: u16) -> anyhow::Resul
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
 
-    let config: Config = Config::parse();
-    utils::tracing::init();
-    metrics::serve(config.metrics_port);
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    match config.inner {
-        ConfigType::Victoria(victoria_config) => {
+    tracing::debug!(?settings, "command-line arguments");
+    metrics::serve(&settings.monitoring);
+
+    match settings.repository_kind {
+        RepositoryKind::VictoriaMetrics => {
             spawn_server(
-                VictoriaQuery::load(victoria_config).await?,
-                config.input_port,
+                VictoriaQuery::load(settings.victoria_metrics.expect("victoria_metrics config"))
+                    .await?,
+                settings.input_port,
             )
             .await
         }
-        ConfigType::Druid(druid_config) => {
-            spawn_server(DruidQuery::load(druid_config).await?, config.input_port).await
+        RepositoryKind::Druid => {
+            spawn_server(
+                DruidQuery::load(settings.druid.expect("druid config")).await?,
+                settings.input_port,
+            )
+            .await
         }
     }
 }

--- a/crates/query-service-ts/src/victoria.rs
+++ b/crates/query-service-ts/src/victoria.rs
@@ -1,18 +1,12 @@
 use anyhow::Context;
 use bb8::{Pool, PooledConnection};
-use clap::Clap;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use rpc::query_service_ts::{
     query_service_ts_server::QueryServiceTs, Range, RawStatement, SchemaId, TimeSeries, ValueBytes,
 };
 use serde::Deserialize;
 use tonic::{Request, Response, Status};
-
-#[derive(Debug, Clap)]
-pub struct VictoriaConfig {
-    #[clap(long = "victoria-query-url", env = "VICTORIA_QUERY_URL")]
-    victoria_url: String,
-}
+use utils::settings::VictoriaMetricsSettings;
 
 pub struct VictoriaConnectionManager;
 
@@ -36,7 +30,7 @@ impl bb8::ManageConnection for VictoriaConnectionManager {
 
 pub struct VictoriaQuery {
     pool: Pool<VictoriaConnectionManager>,
-    addr: String,
+    addr: Url,
 }
 
 #[derive(Deserialize)]
@@ -47,7 +41,7 @@ struct RawStatementParameters {
 }
 
 impl VictoriaQuery {
-    pub async fn load(config: VictoriaConfig) -> anyhow::Result<Self> {
+    pub async fn load(config: VictoriaMetricsSettings) -> anyhow::Result<Self> {
         let pool = Pool::builder()
             .build(VictoriaConnectionManager)
             .await
@@ -55,7 +49,7 @@ impl VictoriaQuery {
 
         Ok(Self {
             pool,
-            addr: config.victoria_url,
+            addr: config.url.join("api/v1")?,
         })
     }
 

--- a/crates/query-service/Cargo.toml
+++ b/crates/query-service/Cargo.toml
@@ -20,7 +20,6 @@ utils       = { path = "../utils" }
 
 # Crates.io
 anyhow      = "1.0"
-clap        = "3.0.0-beta.2"
 bb8         = "0.7"
 reqwest     = { version = "0.11", features = ["json"] }
 serde       = { version = "1.0", features = ["derive"] }

--- a/crates/query-service/src/main.rs
+++ b/crates/query-service/src/main.rs
@@ -1,25 +1,20 @@
 use anyhow::Context;
-use clap::Clap;
 use rpc::query_service::query_service_server::{QueryService, QueryServiceServer};
+use serde::Deserialize;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use tonic::transport::Server;
 use utils::metrics;
+use utils::settings::*;
 
-#[derive(Clap, Debug)]
-pub struct Config {
-    #[clap(subcommand)]
-    pub inner: ConfigType,
-    /// Port to listen on
-    #[clap(long, env)]
-    pub input_port: u16,
-    /// Port to listen on for Prometheus requests
-    #[clap(default_value = metrics::DEFAULT_PORT, env)]
-    pub metrics_port: u16,
-}
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    postgres: PostgresSettings,
+    input_port: u16,
 
-#[derive(Clap, Debug)]
-pub enum ConfigType {
-    Postgres(query_service::psql::PsqlConfig),
+    monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    log: LogSettings,
 }
 
 async fn spawn_server<Q: QueryService>(service: Q, port: u16) -> anyhow::Result<()> {
@@ -36,21 +31,17 @@ async fn spawn_server<Q: QueryService>(service: Q, port: u16) -> anyhow::Result<
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
 
-    let config: Config = Config::parse();
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
 
-    tracing::debug!(?config, "Config");
+    tracing::debug!(?settings, "command-line arguments");
 
-    metrics::serve(config.metrics_port);
+    metrics::serve(&settings.monitoring);
 
-    match config.inner {
-        ConfigType::Postgres(psql_config) => {
-            spawn_server(
-                query_service::psql::PsqlQuery::load(psql_config).await?,
-                config.input_port,
-            )
-            .await
-        }
-    }
+    spawn_server(
+        query_service::psql::PsqlQuery::load(settings.postgres).await?,
+        settings.input_port,
+    )
+    .await
 }

--- a/crates/query-service/src/psql.rs
+++ b/crates/query-service/src/psql.rs
@@ -1,44 +1,19 @@
 use anyhow::Context;
+use bb8_postgres::bb8::{Pool, PooledConnection};
 use bb8_postgres::tokio_postgres::config::Config as PgConfig;
-use bb8_postgres::tokio_postgres::{types::ToSql, NoTls, SimpleQueryMessage};
+use bb8_postgres::tokio_postgres::{types::ToSql, NoTls, RowStream, SimpleQueryMessage};
 use bb8_postgres::PostgresConnectionManager;
-use bb8_postgres::{
-    bb8::{Pool, PooledConnection},
-    tokio_postgres::RowStream,
-};
-use clap::Clap;
 use futures_util::TryStreamExt;
-use rpc::query_service::{query_service_server::QueryService, ObjectStream};
-use rpc::query_service::{Object, ObjectIds, RawStatement, SchemaId, ValueBytes};
+use rpc::query_service::query_service_server::QueryService;
+use rpc::query_service::{Object, ObjectIds, ObjectStream, RawStatement, SchemaId, ValueBytes};
 use serde_json::Value;
 use tonic::{Request, Response, Status};
+use utils::settings::PostgresSettings;
 use utils::{
     metrics::{self, counter},
     psql::validate_schema,
 };
 use uuid::Uuid;
-
-#[derive(Debug, Clap)]
-pub struct PsqlConfig {
-    /// Postgres username
-    #[clap(long, env = "POSTGRES_USERNAME")]
-    username: String,
-    /// Postgres password
-    #[clap(long, env = "POSTGRES_PASSWORD")]
-    password: String,
-    /// Host of the postgres server
-    #[clap(long, env = "POSTGRES_HOST")]
-    host: String,
-    /// Port on which postgres server listens
-    #[clap(long, env = "POSTGRES_PORT", default_value = "5432")]
-    port: u16,
-    /// Database name
-    #[clap(long, env = "POSTGRES_DBNAME")]
-    dbname: String,
-    /// SQL schema available for service
-    #[clap(long, env = "POSTGRES_SCHEMA", default_value = "public")]
-    schema: String,
-}
 
 pub struct PsqlQuery {
     pool: Pool<PostgresConnectionManager<NoTls>>,
@@ -46,21 +21,21 @@ pub struct PsqlQuery {
 }
 
 impl PsqlQuery {
-    pub async fn load(config: PsqlConfig) -> anyhow::Result<Self> {
+    pub async fn load(settings: PostgresSettings) -> anyhow::Result<Self> {
         let mut pg_config = PgConfig::new();
         pg_config
-            .user(&config.username)
-            .password(&config.password)
-            .host(&config.host)
-            .port(config.port)
-            .dbname(&config.dbname);
+            .user(&settings.username)
+            .password(&settings.password)
+            .host(&settings.host)
+            .port(settings.port)
+            .dbname(&settings.dbname);
         let manager = PostgresConnectionManager::new(pg_config, NoTls);
         let pool = Pool::builder()
             .build(manager)
             .await
             .context("Failed to build connection pool")?;
 
-        let schema = config.schema;
+        let schema = settings.schema;
 
         if !validate_schema(&schema) {
             anyhow::bail!(

--- a/crates/rpc/src/edge_registry.rs
+++ b/crates/rpc/src/edge_registry.rs
@@ -7,10 +7,7 @@ pub use crate::codegen::edge_registry::*;
 pub async fn connect(addr: String) -> Result<EdgeRegistryClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "edge registry",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -4,35 +4,8 @@ pub use tonic::{Code, Status};
 
 #[derive(Debug, DeriveError)]
 pub enum ClientError {
-    #[error("Failed to connect to {service}: {source}")]
-    ConnectionError {
-        service: &'static str,
-        source: tonic::transport::Error,
-    },
-    #[error("Error returned from {service}: {source}")]
-    QueryError {
-        service: &'static str,
-        source: Status,
-    },
-}
-
-pub fn schema_registry_error(error: Status) -> ClientError {
-    ClientError::QueryError {
-        service: "schema registry",
-        source: error,
-    }
-}
-
-pub fn edge_registry_error(error: Status) -> ClientError {
-    ClientError::QueryError {
-        service: "edge registry",
-        source: error,
-    }
-}
-
-pub fn object_builder_error(error: Status) -> ClientError {
-    ClientError::QueryError {
-        service: "object builder",
-        source: error,
-    }
+    #[error("Failed to connect to: {source}")]
+    ConnectionError { source: tonic::transport::Error },
+    #[error("Error durign query: {source}")]
+    QueryError { source: Status },
 }

--- a/crates/rpc/src/generic.rs
+++ b/crates/rpc/src/generic.rs
@@ -4,16 +4,10 @@ use tonic::transport::Channel;
 
 pub use crate::codegen::generic_rpc::*;
 
-pub async fn connect(
-    addr: String,
-    service: &'static str,
-) -> Result<GenericRpcClient<Channel>, ClientError> {
+pub async fn connect(addr: String) -> Result<GenericRpcClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service,
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(addr: String) -> Result<GenericRpcClient<Channel>, tonic::transport::Error> {

--- a/crates/rpc/src/materializer_general.rs
+++ b/crates/rpc/src/materializer_general.rs
@@ -7,10 +7,7 @@ pub use crate::codegen::materializer_general::*;
 pub async fn connect(addr: String) -> Result<GeneralMaterializerClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "materializer_general",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(

--- a/crates/rpc/src/materializer_ondemand.rs
+++ b/crates/rpc/src/materializer_ondemand.rs
@@ -7,10 +7,7 @@ pub use crate::codegen::materializer_ondemand::*;
 pub async fn connect(addr: String) -> Result<OnDemandMaterializerClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "materializer_ondemand",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(

--- a/crates/rpc/src/object_builder.rs
+++ b/crates/rpc/src/object_builder.rs
@@ -7,10 +7,7 @@ pub use crate::codegen::object_builder::*;
 pub async fn connect(addr: impl Into<String>) -> Result<ObjectBuilderClient<Channel>, ClientError> {
     connect_inner(addr.into())
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "object builder",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(

--- a/crates/rpc/src/query_service.rs
+++ b/crates/rpc/src/query_service.rs
@@ -12,10 +12,7 @@ pub type ObjectStream<Error = ClientError> =
 pub async fn connect(addr: String) -> Result<QueryServiceClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "query service",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(
@@ -37,15 +34,13 @@ pub async fn query_multiple(
     let stream = conn
         .query_multiple(ObjectIds { object_ids })
         .await
-        .map_err(|err| ClientError::QueryError {
-            service: "query service",
-            source: err,
-        })?;
+        .map_err(|err| ClientError::QueryError { source: err })?;
 
-    let stream = Box::pin(stream.into_inner().map_err(|err| ClientError::QueryError {
-        service: "query service",
-        source: err,
-    }));
+    let stream = Box::pin(
+        stream
+            .into_inner()
+            .map_err(|err| ClientError::QueryError { source: err }),
+    );
 
     Ok(stream)
 }
@@ -55,15 +50,13 @@ pub async fn query_by_schema(schema_id: String, addr: String) -> Result<ObjectSt
     let stream = conn
         .query_by_schema(SchemaId { schema_id })
         .await
-        .map_err(|err| ClientError::QueryError {
-            service: "query service",
-            source: err,
-        })?;
+        .map_err(|err| ClientError::QueryError { source: err })?;
 
-    let stream = Box::pin(stream.into_inner().map_err(|err| ClientError::QueryError {
-        service: "query service",
-        source: err,
-    }));
+    let stream = Box::pin(
+        stream
+            .into_inner()
+            .map_err(|err| ClientError::QueryError { source: err }),
+    );
 
     Ok(stream)
 }
@@ -73,10 +66,7 @@ pub async fn query_raw(raw_statement: String, addr: String) -> Result<Vec<u8>, C
     let response = conn
         .query_raw(RawStatement { raw_statement })
         .await
-        .map_err(|err| ClientError::QueryError {
-            service: "query service",
-            source: err,
-        })?;
+        .map_err(|err| ClientError::QueryError { source: err })?;
 
     Ok(response.into_inner().value_bytes)
 }

--- a/crates/rpc/src/query_service_ts.rs
+++ b/crates/rpc/src/query_service_ts.rs
@@ -7,10 +7,7 @@ pub use crate::codegen::query_service_ts::*;
 pub async fn connect(addr: String) -> Result<QueryServiceTsClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "timeseries query service",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(
@@ -42,10 +39,7 @@ pub async fn query_by_range(
             step,
         })
         .await
-        .map_err(|err| ClientError::QueryError {
-            service: "timeseries query service",
-            source: err,
-        })?;
+        .map_err(|err| ClientError::QueryError { source: err })?;
 
     Ok(response.into_inner().timeseries)
 }
@@ -55,10 +49,7 @@ pub async fn query_by_schema(schema_id: String, addr: String) -> Result<String, 
     let response = conn
         .query_by_schema(SchemaId { schema_id })
         .await
-        .map_err(|err| ClientError::QueryError {
-            service: "timeseries query service",
-            source: err,
-        })?;
+        .map_err(|err| ClientError::QueryError { source: err })?;
 
     Ok(response.into_inner().timeseries)
 }
@@ -68,10 +59,7 @@ pub async fn query_raw(raw_statement: String, addr: String) -> Result<Vec<u8>, C
     let response = conn
         .query_raw(RawStatement { raw_statement })
         .await
-        .map_err(|err| ClientError::QueryError {
-            service: "timeseries query service",
-            source: err,
-        })?;
+        .map_err(|err| ClientError::QueryError { source: err })?;
 
     Ok(response.into_inner().value_bytes)
 }

--- a/crates/rpc/src/schema_registry.rs
+++ b/crates/rpc/src/schema_registry.rs
@@ -9,10 +9,7 @@ use tonic::transport::Channel;
 pub async fn connect(addr: String) -> Result<SchemaRegistryClient<Channel>, ClientError> {
     connect_inner(addr)
         .await
-        .map_err(|err| ClientError::ConnectionError {
-            service: "schema registry",
-            source: err,
-        })
+        .map_err(|err| ClientError::ConnectionError { source: err })
 }
 
 async fn connect_inner(

--- a/crates/schema-registry/Cargo.toml
+++ b/crates/schema-registry/Cargo.toml
@@ -21,7 +21,6 @@ utils       = { path = "../utils" }
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap        = "3.0.0-beta.2"
 jmespatch   = "0.3"
 jsonschema  = { version = "0.8", default-features = false }
 semver      = { version = "0.11", features = ["serde"] }

--- a/crates/schema-registry/src/db.rs
+++ b/crates/schema-registry/src/db.rs
@@ -10,8 +10,8 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tracing::{trace, warn};
 use uuid::Uuid;
 
-use crate::config::Config;
 use crate::error::{RegistryError, RegistryResult};
+use crate::settings::Settings;
 use crate::types::schema::{FullSchema, NewSchema, Schema, SchemaDefinition, SchemaUpdate};
 use crate::types::view::{NewView, View, ViewUpdate};
 use crate::types::DbExport;
@@ -28,20 +28,20 @@ pub struct SchemaRegistryDb {
 }
 
 impl SchemaRegistryDb {
-    pub async fn new(config: &Config) -> RegistryResult<Self> {
+    pub async fn new(config: &Settings) -> RegistryResult<Self> {
         let options = PgConnectOptions::new()
-            .host(&config.db_host)
-            .port(config.db_port)
-            .username(&config.db_username)
-            .password(&config.db_password)
-            .database(&config.db_name);
+            .host(&config.postgres.host)
+            .port(config.postgres.port)
+            .username(&config.postgres.username)
+            .password(&config.postgres.password)
+            .database(&config.postgres.dbname);
 
         Ok(Self {
             pool: PgPoolOptions::new()
                 .connect_with(options)
                 .await
                 .map_err(RegistryError::ConnectionError)?,
-            db_schema: config.db_schema.clone(),
+            db_schema: config.postgres.schema.clone(),
         })
     }
 

--- a/crates/schema-registry/src/lib.rs
+++ b/crates/schema-registry/src/lib.rs
@@ -1,8 +1,8 @@
 #![feature(drain_filter)]
 
-pub mod config;
 pub mod db;
 pub mod error;
 pub mod rpc;
+pub mod settings;
 pub mod types;
 pub mod utils;

--- a/crates/schema-registry/src/main.rs
+++ b/crates/schema-registry/src/main.rs
@@ -1,39 +1,39 @@
+use anyhow::Context;
+use rpc::schema_registry::schema_registry_server::SchemaRegistryServer;
+use schema_registry::rpc::SchemaRegistryImpl;
+use schema_registry::settings::Settings;
 use std::fs::File;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::PathBuf;
-
-use anyhow::Context;
-use clap::Clap;
 use tokio::time::sleep;
 use tokio::time::Duration;
 use tonic::transport::Server;
-
-use rpc::schema_registry::schema_registry_server::SchemaRegistryServer;
-use schema_registry::config::{communication_config, Config};
-use schema_registry::rpc::SchemaRegistryImpl;
+use utils::settings::load_settings;
 use utils::{metrics, status_endpoints};
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
     utils::set_aborting_panic_hook();
-    utils::tracing::init();
-    let config = Config::parse();
+
+    let settings: Settings = load_settings()?;
+    ::utils::tracing::init(settings.log.rust_log.as_str())?;
+
+    tracing::debug!(?settings, "command-line arguments");
 
     sleep(Duration::from_millis(500)).await;
 
-    status_endpoints::serve(config.status_port);
-    metrics::serve(config.metrics_port);
+    status_endpoints::serve(&settings.monitoring);
+    metrics::serve(&settings.monitoring);
 
-    let comms_config = communication_config(&config)?;
-    let registry = SchemaRegistryImpl::new(&config, comms_config).await?;
+    let registry = SchemaRegistryImpl::new(&settings).await?;
 
-    if let Some(export_filename) = config.export_dir.map(export_path) {
+    if let Some(export_filename) = settings.export_dir.map(export_path) {
         let exported = registry.export_all().await?;
         let file = File::create(export_filename)?;
         serde_json::to_writer_pretty(&file, &exported)?;
     }
 
-    if let Some(import_path) = config.import_file {
+    if let Some(import_path) = settings.import_file {
         let imported = File::open(import_path).map_err(|err| anyhow::anyhow!("{}", err))?;
         let imported = serde_json::from_reader(imported)?;
         registry
@@ -42,7 +42,7 @@ pub async fn main() -> anyhow::Result<()> {
             .map_err(|err| anyhow::anyhow!("Failed to import database: {}", err))?;
     }
 
-    let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), config.input_port);
+    let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), settings.input_port);
     status_endpoints::mark_as_started();
     Server::builder()
         .trace_fn(utils::tracing::grpc::trace_fn)

--- a/crates/schema-registry/src/rpc.rs
+++ b/crates/schema-registry/src/rpc.rs
@@ -9,10 +9,9 @@ use tokio_stream::{Stream, StreamExt};
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
-use crate::config::CommunicationMethodConfig;
-use crate::config::Config;
 use crate::db::SchemaRegistryDb;
 use crate::error::{RegistryError, RegistryResult};
+use crate::settings::Settings;
 use crate::types::schema::{NewSchema, SchemaDefinition, SchemaUpdate};
 use crate::types::view::{NewView, ViewUpdate};
 use crate::types::{DbExport, VersionedUuid};
@@ -29,20 +28,9 @@ pub struct SchemaRegistryImpl {
 }
 
 impl SchemaRegistryImpl {
-    pub async fn new(
-        config: &Config,
-        communication_config: CommunicationMethodConfig,
-    ) -> anyhow::Result<Self> {
-        let db = SchemaRegistryDb::new(config).await?;
-        let mq_metadata = match &communication_config {
-            CommunicationMethodConfig::Kafka(kafka) => {
-                MetadataFetcher::new_kafka(&kafka.brokers).await?
-            }
-            CommunicationMethodConfig::Amqp(amqp) => {
-                MetadataFetcher::new_amqp(&amqp.connection_string).await?
-            }
-            CommunicationMethodConfig::Grpc => MetadataFetcher::new_grpc("command_service").await?,
-        };
+    pub async fn new(settings: &Settings) -> anyhow::Result<Self> {
+        let mq_metadata = settings.metadata_fetcher().await?;
+        let db = SchemaRegistryDb::new(settings).await?;
 
         Ok(Self { db, mq_metadata })
     }

--- a/crates/schema-registry/src/settings.rs
+++ b/crates/schema-registry/src/settings.rs
@@ -1,0 +1,47 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+use utils::communication::metadata_fetcher::MetadataFetcher;
+use utils::settings::*;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub communication_method: CommunicationMethod,
+    pub input_port: u16,
+    pub import_file: Option<PathBuf>,
+    pub export_dir: Option<PathBuf>,
+
+    pub postgres: PostgresSettings,
+
+    pub kafka: Option<KafkaSettings>,
+    pub amqp: Option<AmqpSettings>,
+
+    pub monitoring: MonitoringSettings,
+
+    #[serde(default)]
+    pub log: LogSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KafkaSettings {
+    pub brokers: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AmqpSettings {
+    pub exchange_url: String,
+}
+
+impl Settings {
+    pub async fn metadata_fetcher(&self) -> anyhow::Result<MetadataFetcher> {
+        Ok(match (&self.kafka, &self.amqp, self.communication_method) {
+            (Some(kafka), _, CommunicationMethod::Kafka) => {
+                MetadataFetcher::new_kafka(kafka.brokers.as_str()).await?
+            }
+            (_, Some(amqp), CommunicationMethod::Amqp) => {
+                MetadataFetcher::new_amqp(amqp.exchange_url.as_str()).await?
+            }
+            (_, _, CommunicationMethod::GRpc) => MetadataFetcher::new_grpc()?,
+            _ => anyhow::bail!("Unsupported consumer specification"),
+        })
+    }
+}

--- a/crates/tracing_tools/Cargo.toml
+++ b/crates/tracing_tools/Cargo.toml
@@ -16,6 +16,7 @@ kafka = ["rdkafka"]
 http = ["warp", "reqwest", "hyper", "tower-service", "opentelemetry-http"]
 
 [dependencies]
+anyhow      = "1.0"
 hyper       = { version = "0.14", optional = true }
 rdkafka     = { version = "0.26", features = ["cmake-build"], optional = true }
 reqwest     = { version = "0.11", features = ["json"], optional = true }

--- a/crates/tracing_tools/src/lib.rs
+++ b/crates/tracing_tools/src/lib.rs
@@ -2,6 +2,7 @@ use opentelemetry::global;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use tokio::runtime::Handle;
 use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
 
 #[cfg(feature = "grpc")]
 pub mod grpc;
@@ -10,7 +11,7 @@ pub mod http;
 #[cfg(feature = "kafka")]
 pub mod kafka;
 
-pub fn init() {
+pub fn init<'a>(rust_log: impl Into<Option<&'a str>>) -> anyhow::Result<()> {
     global::set_text_map_propagator(TraceContextPropagator::new());
 
     let opentelemetry = Handle::try_current()
@@ -24,10 +25,16 @@ pub fn init() {
 
     let fmt = tracing_subscriber::fmt::layer();
 
+    let filter = rust_log
+        .into()
+        .map(EnvFilter::new)
+        .unwrap_or_else(EnvFilter::from_default_env);
+
     tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(filter)
         .with(fmt)
         .with(opentelemetry)
-        .try_init()
-        .unwrap();
+        .try_init()?;
+
+    Ok(())
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -17,7 +17,9 @@ tracing_tools           = { path    = "../tracing_tools", features = ["kafka", "
 # Crates.io
 anyhow      = "1.0"
 async-trait = "0.1"
-clap        = "3.0.0-beta.2"
+config      = "0.11"
+derive_more = { version = "0.99.13", features = ["display"] }
+dirs        = "3.0.2"
 hyper       = "0.14"
 lapin       = "1.7"
 lazy_static = "1.4"
@@ -30,7 +32,7 @@ thiserror   = "1.0"
 tokio       = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-amqp  = "1.0"
 tracing     = "0.1"
-url         = "2.2"
+url         = { version = "2.2", features = ["serde"] }
 uuid        = { version = "0.8", features = ["v4", "serde"] }
 vec_map     = "0.8"
 async-stream            = "0.3"

--- a/crates/utils/src/communication/parallel_consumer.rs
+++ b/crates/utils/src/communication/parallel_consumer.rs
@@ -134,6 +134,8 @@ impl ParallelCommonConsumer {
             .create()
             .context("Consumer creation failed")?;
 
+        eprintln!("{:?}", topics);
+
         rdkafka::consumer::Consumer::subscribe(&consumer, topics)
             .context("Can't subscribe to specified topics")?;
 

--- a/crates/utils/src/communication/publisher.rs
+++ b/crates/utils/src/communication/publisher.rs
@@ -17,7 +17,7 @@ pub enum CommonPublisher {
     Kafka { producer: FutureProducer },
     Amqp { channel: Channel },
     Rest { url: Url, client: Client },
-    Grpc { service: &'static str },
+    Grpc,
 }
 impl CommonPublisher {
     pub async fn new_amqp(connection_string: &str) -> Result<Self> {
@@ -51,8 +51,8 @@ impl CommonPublisher {
         })
     }
 
-    pub async fn new_grpc(service: &'static str) -> Result<Self> {
-        Ok(Self::Grpc { service })
+    pub async fn new_grpc() -> Result<Self> {
+        Ok(Self::Grpc)
     }
 
     pub async fn publish_message(
@@ -93,9 +93,9 @@ impl CommonPublisher {
 
                 Ok(())
             }
-            CommonPublisher::Grpc { service } => {
+            CommonPublisher::Grpc => {
                 let addr = destination.into();
-                let mut client = rpc::generic::connect(addr, service).await?;
+                let mut client = rpc::generic::connect(addr).await?;
                 let response = client
                     .handle(rpc::generic::Message {
                         key: key.into(),

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,12 +1,13 @@
 #![feature(linked_list_cursors)]
 #![feature(box_syntax)]
 
-use ::tracing::error;
 use std::{
     panic, process,
     sync::PoisonError,
     time::{SystemTime, UNIX_EPOCH},
 };
+
+use ::tracing::error;
 
 pub mod communication;
 pub mod message_types;
@@ -15,6 +16,7 @@ pub mod notification;
 pub mod parallel_task_queue;
 pub mod psql;
 pub mod query_utils;
+pub mod settings;
 pub mod status_endpoints;
 pub mod task_limiter;
 pub mod types;

--- a/crates/utils/src/metrics.rs
+++ b/crates/utils/src/metrics.rs
@@ -3,15 +3,19 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tracing::debug;
 
+use crate::settings::MonitoringSettings;
 pub use metrics::{self, counter, gauge, try_recorder, Key, KeyData, SharedString};
 
 pub const DEFAULT_PORT: &str = "51805";
 
-pub fn serve(port: u16) {
-    debug!("Initializing metrics at port {}", port);
+pub fn serve(settings: &MonitoringSettings) {
+    debug!("Initializing metrics at port {}", settings.metrics_port);
 
     PrometheusBuilder::new()
-        .listen_address(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port))
+        .listen_address(SocketAddrV4::new(
+            Ipv4Addr::new(0, 0, 0, 0),
+            settings.metrics_port,
+        ))
         .install()
         .expect("failed to install Prometheus recorder");
 }

--- a/crates/utils/src/notification/mod.rs
+++ b/crates/utils/src/notification/mod.rs
@@ -2,14 +2,12 @@ use crate::message_types::OwnMessage;
 use crate::notification::full_notification_sender::{
     FullNotificationSender, FullNotificationSenderBase,
 };
-pub use config::NotificationServiceConfig;
 use serde::Serialize;
 
-mod config;
 pub mod full_notification_sender;
 
 #[derive(Clone)]
-pub enum NotificationSender<T>
+pub enum NotificationPublisher<T>
 where
     T: Serialize + Send + Sync + 'static,
 {
@@ -29,7 +27,7 @@ impl NotificationService for () {
     }
 }
 
-impl<T> NotificationSender<T>
+impl<T> NotificationPublisher<T>
 where
     T: Serialize + Send + Sync + 'static,
 {
@@ -38,14 +36,14 @@ where
         U: OwnMessage<Owned = T>,
     {
         match self {
-            NotificationSender::Full(config) => Box::new(FullNotificationSender {
+            NotificationPublisher::Full(config) => Box::new(FullNotificationSender {
                 application: config.application,
                 producer: config.publisher,
                 destination: config.destination,
                 context: config.context,
                 msg: msg.to_owned_message(),
             }),
-            NotificationSender::Disabled => Box::new(()),
+            NotificationPublisher::Disabled => Box::new(()),
         }
     }
 }

--- a/crates/utils/src/settings.rs
+++ b/crates/utils/src/settings.rs
@@ -1,0 +1,251 @@
+use crate::communication::consumer::{CommonConsumer, CommonConsumerConfig};
+use crate::communication::parallel_consumer::{
+    ParallelCommonConsumer, ParallelCommonConsumerConfig,
+};
+use crate::communication::publisher::CommonPublisher;
+use crate::notification::full_notification_sender::FullNotificationSenderBase;
+use crate::notification::NotificationPublisher;
+use crate::task_limiter::TaskLimiter;
+use anyhow::bail;
+use config::{Config, Environment, File};
+use derive_more::Display;
+use lapin::options::BasicConsumeOptions;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fmt::Debug;
+use std::net::SocketAddrV4;
+use url::Url;
+
+#[derive(Clone, Copy, Debug, Deserialize, Display, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunicationMethod {
+    Kafka,
+    Amqp,
+    #[serde(rename = "grpc")]
+    GRpc,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct PostgresSettings {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub dbname: String,
+    pub schema: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct VictoriaMetricsSettings {
+    pub url: Url,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ConsumerKafkaSettings {
+    pub brokers: String,
+    pub group_id: String,
+    pub ingest_topic: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct PublisherKafkaSettings {
+    pub brokers: String,
+    pub egest_topic: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AmqpSettings {
+    pub exchange_url: String,
+    pub tag: String,
+    pub ingest_queue: String,
+    pub consume_options: Option<BasicConsumeOptions>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct GRpcSettings {
+    pub address: SocketAddrV4,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct NotificationSettings {
+    /// Kafka topic, AMQP queue or GRPC url
+    #[serde(default)]
+    pub destination: String,
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct MonitoringSettings {
+    #[serde(default)]
+    pub metrics_port: u16,
+    #[serde(default)]
+    pub stats_port: u16,
+    #[serde(default = "default_otel_service_name")]
+    pub otel_service_name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct LogSettings {
+    pub rust_log: String,
+}
+
+impl Default for LogSettings {
+    fn default() -> Self {
+        Self {
+            rust_log: "info".to_string(),
+        }
+    }
+}
+
+fn default_otel_service_name() -> String {
+    env::current_exe().unwrap().to_string_lossy().to_string()
+}
+
+pub fn load_settings<'de, T: Deserialize<'de> + Debug>() -> anyhow::Result<T> {
+    let env = env::var("ENVIRONMENT").unwrap_or_else(|_| "development".to_string());
+    let exe = if let Some(exe) =
+        env::current_exe().map(|f| f.file_name().map(|s| s.to_string_lossy().to_string()))?
+    {
+        exe
+    } else {
+        bail!("Missing executable file name")
+    };
+    let mut s = Config::new();
+
+    s.merge(File::with_name("/etc/cdl/default.toml").required(false))?;
+    s.merge(File::with_name(&format!("/etc/cdl/{}.toml", exe)).required(false))?;
+
+    if let Some(home) = dirs::home_dir() {
+        s.merge(
+            File::with_name(&format!(
+                "{}/.cdl/{}/default.toml",
+                home.to_string_lossy(),
+                env
+            ))
+            .required(false),
+        )?;
+        s.merge(
+            File::with_name(&format!(
+                "{}/.cdl/{}/{}.toml",
+                home.to_string_lossy(),
+                env,
+                exe
+            ))
+            .required(false),
+        )?;
+    }
+
+    s.merge(File::with_name(&format!(".cdl/{}/default.toml", env)).required(false))?;
+    s.merge(File::with_name(&format!(".cdl/{}/{}.toml", env, exe)).required(false))?;
+
+    if let Ok(custom_dir) = env::var("CDL_CONFIG") {
+        s.merge(File::with_name(&format!("{}/{}/default.toml", custom_dir, env)).required(false))?;
+        s.merge(File::with_name(&format!("{}/{}/{}.toml", custom_dir, env, exe)).required(false))?;
+    }
+
+    s.merge(Environment::with_prefix(&exe.replace("-", "_")).separator("__"))?;
+
+    let settings = s.try_into()?;
+
+    Ok(settings)
+}
+
+pub async fn publisher<'a>(
+    kafka: Option<&'a str>,
+    amqp: Option<&'a str>,
+    grpc: Option<()>,
+) -> anyhow::Result<CommonPublisher> {
+    Ok(match (kafka, amqp, grpc) {
+        (Some(brokers), _, _) => CommonPublisher::new_kafka(brokers).await?,
+        (_, Some(exchange), _) => CommonPublisher::new_amqp(exchange).await?,
+        (_, _, Some(_)) => CommonPublisher::new_grpc().await?,
+        _ => anyhow::bail!("Unsupported publisher specification"),
+    })
+}
+
+impl ConsumerKafkaSettings {
+    pub async fn consumer(&self) -> anyhow::Result<CommonConsumer> {
+        Ok(CommonConsumer::new(CommonConsumerConfig::Kafka {
+            brokers: &self.brokers,
+            group_id: &self.group_id,
+            topic: self.ingest_topic.as_str(),
+        })
+        .await?)
+    }
+
+    pub async fn parallel_consumer(
+        &self,
+        task_limiter: TaskLimiter,
+    ) -> anyhow::Result<ParallelCommonConsumer> {
+        Ok(
+            ParallelCommonConsumer::new(ParallelCommonConsumerConfig::Kafka {
+                brokers: &self.brokers,
+                group_id: &self.group_id,
+                topic: &self.ingest_topic,
+                task_limiter,
+            })
+            .await?,
+        )
+    }
+}
+
+impl AmqpSettings {
+    pub async fn consumer(&self) -> anyhow::Result<CommonConsumer> {
+        Ok(CommonConsumer::new(CommonConsumerConfig::Amqp {
+            connection_string: &self.exchange_url,
+            consumer_tag: &self.tag,
+            queue_name: &self.ingest_queue,
+            options: self.consume_options,
+        })
+        .await?)
+    }
+
+    pub async fn parallel_consumer(
+        &self,
+        task_limiter: TaskLimiter,
+    ) -> anyhow::Result<ParallelCommonConsumer> {
+        Ok(
+            ParallelCommonConsumer::new(ParallelCommonConsumerConfig::Amqp {
+                connection_string: &self.exchange_url,
+                consumer_tag: &self.tag,
+                queue_name: &self.ingest_queue,
+                options: self.consume_options,
+                task_limiter,
+            })
+            .await?,
+        )
+    }
+}
+
+impl GRpcSettings {
+    pub async fn parallel_consumer(&self) -> anyhow::Result<ParallelCommonConsumer> {
+        Ok(
+            ParallelCommonConsumer::new(ParallelCommonConsumerConfig::Grpc { addr: self.address })
+                .await?,
+        )
+    }
+}
+
+impl NotificationSettings {
+    pub async fn publisher<T: Serialize + Send + Sync + 'static>(
+        &self,
+        publisher: CommonPublisher, // FIXME
+        context: String,
+        application: &'static str,
+    ) -> NotificationPublisher<T> {
+        if self.enabled {
+            NotificationPublisher::Full(
+                FullNotificationSenderBase::new(
+                    publisher,
+                    self.destination.clone(),
+                    context,
+                    application,
+                )
+                .await,
+            )
+        } else {
+            NotificationPublisher::Disabled
+        }
+    }
+}

--- a/crates/utils/src/status_endpoints.rs
+++ b/crates/utils/src/status_endpoints.rs
@@ -1,3 +1,4 @@
+use crate::settings::MonitoringSettings;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use lazy_static::lazy_static;
@@ -12,8 +13,8 @@ lazy_static! {
     static ref READY_STATUS: RwLock<bool> = RwLock::new(true);
 }
 
-pub fn serve(port: u16) {
-    tokio::spawn(serve_status(port));
+pub fn serve(settings: &MonitoringSettings) {
+    tokio::spawn(serve_status(settings.stats_port));
 }
 pub fn get_health_status() -> bool {
     *HEALTH_STATUS.read().unwrap()


### PR DESCRIPTION
Most of these changes are refactorings. I've unified way we manage our configs. No more cli - it started to become messy, in some places we had need for multiple subcommands.

This is not standalone - there are other PR's tackling this feature. Tests are supposed to pass only after all subPR's are merged.