### PR TITLE
fix: schema registry docker-compose definitions and setup

### DIFF
--- a/deployment/compose/docker-compose.cdl.grpc.base.yml
+++ b/deployment/compose/docker-compose.cdl.grpc.base.yml
@@ -18,14 +18,20 @@ services:
     ports:
       - "50101:50101"
     environment:
-      DB_NAME: "/var/data/schema"
       REPLICATION_ROLE: "master"
       COMMUNICATION_METHOD: "grpc"
-      REPLICATION_SOURCE: "none"
-      REPLICATION_DESTINATION: "none"
       INPUT_PORT: "50101"
       IMPORT_FILE: "/var/data/schema.json"
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DBNAME: postgres
+      POSTGRES_SCHEMA: cdl
       RUST_LOG: info,schema_registry=trace
+      OTEL_SERVICE_NAME: "schema-registry"
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
     volumes:
       - ./setup/schema_registry/initial-schema.grpc.json:/var/data/schema.json
 
@@ -46,6 +52,9 @@ services:
       SCHEMA_REGISTRY_ADDR: "http://schema_registry:50101"
       CACHE_CAPACITY: "1000"
       RUST_LOG: info,data_router=trace
+      OTEL_SERVICE_NAME: "data-router"
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
 
   query_router:
     image: cdl-query-router:latest
@@ -63,6 +72,9 @@ services:
       INPUT_PORT: 50103
       SCHEMA_REGISTRY_ADDR: "http://schema_registry:50101"
       RUST_LOG: info,query_router=trace
+      OTEL_SERVICE_NAME: "query-router"
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
 
   object_builder:
     image: cdl-object-builder:latest
@@ -80,6 +92,25 @@ services:
       SCHEMA_REGISTRY_ADDR: "http://schema_registry:50101"
       RUST_LOG: info,object_builder=trace
 
+  materializer_ondemand:
+    image: cdl-materializer-ondemand:latest
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        - BIN=materializer-ondemand
+        - ENV=DEV
+    command: "/bin/materializer-ondemand"
+    ports:
+      - "50108:50108"
+    environment:
+      INPUT_PORT: "50108"
+      OBJECT_BUILDER_ADDR: "http://object_builder:50107"
+      RUST_LOG: info,materializer_ondemand=trace
+      OTEL_SERVICE_NAME: "materializer-ondemand"
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
+
   web_api:
     image: cdl-api:latest
     command: "/bin/api"
@@ -94,10 +125,14 @@ services:
       INPUT_PORT: 50106
       RUST_LOG: info,api=trace
       SCHEMA_REGISTRY_ADDR: "http://schema_registry:50101"
+      EDGE_REGISTRY_ADDR: "http://edge_registry:50110"
+      ON_DEMAND_MATERIALIZER_ADDR: "http://materializer_ondemand:50108"
       QUERY_ROUTER_ADDR: "http://query_router:50103"
-      OBJECT_BUILDER_ADDR: "http://object_builder:50107"
       COMMUNICATION_METHOD: "grpc"
       INSERT_DESTINATION: "http://data_router:50102"
+      OTEL_SERVICE_NAME: "api"
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
 
 networks:
   compose_default:

--- a/deployment/compose/docker-compose.cdl.kafka.base.yml
+++ b/deployment/compose/docker-compose.cdl.kafka.base.yml
@@ -18,15 +18,17 @@ services:
     ports:
       - "50101:50101"
     environment:
-      DB_NAME: "/var/data/schema"
-      REPLICATION_ROLE: "master"
       COMMUNICATION_METHOD: "kafka"
       KAFKA_BROKERS: "kafka:9093"
       KAFKA_GROUP_ID: "schema_registry"
-      REPLICATION_SOURCE: "cdl.schema_registry.internal"
-      REPLICATION_DESTINATION: "cdl.schema_registry.internal"
       INPUT_PORT: "50101"
       IMPORT_FILE: "/var/data/schema.json"
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DBNAME: postgres
+      POSTGRES_SCHEMA: cdl
       RUST_LOG: info,schema_registry=trace
       OTEL_SERVICE_NAME: "schema-registry"
       OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"

--- a/deployment/compose/docker-compose.cdl.rabbitmq.base.yml
+++ b/deployment/compose/docker-compose.cdl.rabbitmq.base.yml
@@ -18,13 +18,15 @@ services:
     ports:
       - "50101:50101"
     environment:
-      DB_NAME: "/var/data/schema"
-      REPLICATION_ROLE: "master"
       COMMUNICATION_METHOD: "amqp"
       AMQP_CONNECTION_STRING: "amqp://user:CHANGEME@rabbitmq:5672/%2f"
       AMQP_CONSUMER_TAG: "schema_registry"
-      REPLICATION_SOURCE: "cdl.schema_registry.internal"
-      REPLICATION_DESTINATION: "cdl.schema_registry.internal"
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DBNAME: postgres
+      POSTGRES_SCHEMA: cdl
       INPUT_PORT: "50101"
       IMPORT_FILE: "/var/data/schema.json"
       RUST_LOG: info,schema_registry=trace
@@ -127,11 +129,31 @@ services:
       OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
       OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
 
+  materializer_ondemand:
+    image: cdl-materializer-ondemand:latest
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        - BIN=materializer-ondemand
+        - ENV=DEV
+    command: "/bin/materializer-ondemand"
+    ports:
+      - "50108:50108"
+    environment:
+      INPUT_PORT: "50108"
+      OBJECT_BUILDER_ADDR: "http://object_builder:50107"
+      RUST_LOG: info,materializer_ondemand=trace
+      OTEL_SERVICE_NAME: "materializer-ondemand"
+      OTEL_EXPORTER_JAEGER_AGENT_HOST: "jaeger"
+      OTEL_EXPORTER_JAEGER_AGENT_PORT: "6831"
+
+
   web_api:
     image: cdl-api:latest
     command: "/bin/api"
     ports:
-      - "50104:50104"
+      - "50106:50106"
     build:
       context: ../..
       dockerfile: Dockerfile
@@ -143,7 +165,7 @@ services:
       SCHEMA_REGISTRY_ADDR: "http://schema_registry:50101"
       QUERY_ROUTER_ADDR: "http://query_router:50103"
       EDGE_REGISTRY_ADDR: "http://edge_registry:50110"
-      OBJECT_BUILDER_ADDR: "http://object_builder:50107"
+      ON_DEMAND_MATERIALIZER_ADDR: "http://materializer_ondemand:50108"
       COMMUNICATION_METHOD: "amqp"
       AMQP_CONNECTION_STRING: "amqp://user:CHANGEME@rabbitmq:5672/%2f"
       AMQP_CONSUMER_TAG: "cdl-api"

--- a/deployment/compose/docker-compose.cdl.rabbitmq.postgres.yml
+++ b/deployment/compose/docker-compose.cdl.rabbitmq.postgres.yml
@@ -51,6 +51,27 @@ services:
       INPUT_PORT: 50201
       RUST_LOG: info,query_service=trace
 
+  postgres_materializer:
+    image: cdl-materializer:latest
+    command: "/bin/materializer postgres"
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      args:
+        - BIN=materializer
+        - ENV=DEV
+    ports:
+      - "50203:50203"
+    environment:
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DBNAME: postgres
+      POSTGRES_SCHEMA: cdl
+      INPUT_PORT: 50203
+      RUST_LOG: info,materializer=trace
+
 networks:
   compose_default:
     external: true

--- a/deployment/compose/setup-postgres-grpc.sh
+++ b/deployment/compose/setup-postgres-grpc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker-compose down --remove-orphans
+docker-compose -f docker-compose.yml up -d postgres jaeger
+
+sleep 15s
+
+docker-compose \
+    -f docker-compose.yml \
+    -f docker-compose.cdl.grpc.base.yml \
+    -f docker-compose.cdl.grpc.postgres.yml \
+    up -d \
+    schema_registry # object builder needs it to be running
+
+sleep 1s
+
+docker-compose \
+    -f docker-compose.yml \
+    -f docker-compose.cdl.grpc.base.yml \
+    -f docker-compose.cdl.grpc.postgres.yml \
+    up \
+    schema_registry \
+    postgres_query \
+    postgres_command \
+    postgres_materializer \
+    web_api \
+    query_router \
+    data_router \
+    object_builder \
+    materializer_ondemand

--- a/deployment/compose/setup-postgres-rabbit.sh
+++ b/deployment/compose/setup-postgres-rabbit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker-compose down --remove-orphans
+docker-compose -f docker-compose.yml up -d postgres rabbitmq jaeger
+
+sleep 15s
+
+docker-compose \
+    -f docker-compose.yml \
+    -f docker-compose.cdl.rabbitmq.base.yml \
+    -f docker-compose.cdl.rabbitmq.postgres.yml \
+    up -d \
+    schema_registry # object builder needs it to be running
+
+sleep 1s
+
+docker-compose \
+    -f docker-compose.yml \
+    -f docker-compose.cdl.rabbitmq.base.yml \
+    -f docker-compose.cdl.rabbitmq.postgres.yml \
+    up \
+    schema_registry \
+    postgres_query \
+    postgres_command \
+    postgres_materializer \
+    web_api \
+    query_router \
+    data_router \
+    object_builder \
+    materializer_ondemand

--- a/deployment/compose/setup/postgres/2-schema.sql
+++ b/deployment/compose/setup/postgres/2-schema.sql
@@ -25,12 +25,10 @@ CREATE TABLE views (
     materializer_address varchar not null,
     materializer_options json not null,
     fields               json not null,
-    base_schema          uuid not null,
-    relations            json not null,
-    filters              json not null,
+    schema               uuid not null,
 
-    CONSTRAINT fk_base_schema_1
-        FOREIGN KEY(base_schema)
+    CONSTRAINT fk_schema_1
+        FOREIGN KEY(schema)
         REFERENCES schemas(id)
         ON UPDATE CASCADE
         ON DELETE CASCADE

--- a/deployment/compose/setup/rabbitmq/definitions.json
+++ b/deployment/compose/setup/rabbitmq/definitions.json
@@ -84,6 +84,15 @@
       "arguments": {
         "x-queue-type": "classic"
       }
+    },
+    {
+      "name": "cdl.materialize",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-queue-type": "classic"
+      }
     }
   ],
   "exchanges": [
@@ -134,6 +143,15 @@
     },
     {
       "name": "cdl.edge.input",
+      "vhost": "/",
+      "type": "topic",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
+    },
+    {
+      "name": "cdl.materialize",
       "vhost": "/",
       "type": "topic",
       "durable": true,
@@ -203,6 +221,14 @@
       "source": "cdl.edge.input",
       "vhost": "/",
       "destination": "cdl.edge.input",
+      "destination_type": "queue",
+      "routing_key": "unordered",
+      "arguments": {}
+    },
+    {
+      "source": "cdl.materialize",
+      "vhost": "/",
+      "destination": "cdl.materialize",
       "destination_type": "queue",
       "routing_key": "unordered",
       "arguments": {}

--- a/deployment/compose/setup/schema_registry/initial-schema.grpc.json
+++ b/deployment/compose/setup/schema_registry/initial-schema.grpc.json
@@ -1,57 +1,51 @@
 {
-  "schema_views": [
+  "schemas": [
     {
-      "view_id": "ec8cc976-412b-11eb-8000-000000000000",
-      "schema_id": "2cfad3c7-411a-11eb-8000-000000000000"
-    }
-  ],
-  "schema_definitions": [
-    {
-      "version": "1.0.0",
-      "definition_id": "2cfad4e7-411a-11eb-8001-000000000000",
-      "schema_id": "2cfad3c7-411a-11eb-8000-000000000000"
-    },
-    {
-      "version": "1.0.0",
-      "definition_id": "a5e0c96b-412c-11eb-8001-000000000000",
-      "schema_id": "a5e0c7e2-412c-11eb-8000-000000000000"
-    }
-  ],
-  "views": {
-    "ec8cc976-412b-11eb-8000-000000000000": {
-      "materializer_addr": "http://materializer:1234",
-      "name": "new view",
-      "fields": {
-        "foo": {
-          "FieldName": "a"
+      "id": "2cfad3c7-411a-11eb-8000-000000000000",
+      "type": "DocumentStorage",
+      "query_address": "http://postgres_query:50201",
+      "insert_destination": "http://postgres_command:50202",
+      "name": "new schema",
+      "views": [
+        {
+          "id": "ec8cc976-412b-11eb-8000-000000000000",
+          "materializer_address": "http://postgres_materializer:50203",
+          "name": "new view",
+          "materializer_options": {
+            "table": "MATERIALIZED_VIEW"
+          },
+          "fields": {
+            "foo": {
+              "field_name": "a"
+            }
+          }
         }
-      }
-    }
-  },
-  "definitions": {
-    "a5e0c96b-412c-11eb-8001-000000000000": {
-      "definition": {
-        "b": "string"
-      }
+      ],
+      "definitions": [
+        {
+          "version": "1.0.0",
+          "definition": {
+            "a": "string"
+          }
+        }
+      ]
     },
-    "2cfad4e7-411a-11eb-8001-000000000000": {
-      "definition": {
-        "a": "number"
-      }
-    }
-  },
-  "schemas": {
-    "2cfad3c7-411a-11eb-8000-000000000000": {
-      "schema_type": "DocumentStorage",
+    {
+      "id": "a5e0c7e2-412c-11eb-8000-000000000000",
+      "type": "DocumentStorage",
       "query_address": "http://postgres_query:50201",
       "insert_destination": "http://postgres_command:50202",
-      "name": "new schema"
-    },
-    "a5e0c7e2-412c-11eb-8000-000000000000": {
-      "schema_type": "DocumentStorage",
-      "query_address": "http://postgres_query:50201",
-      "insert_destination": "http://postgres_command:50202",
-      "name": "second schema"
+      "name": "second schema",
+      "views": [],
+      "definitions": [
+        {
+          "version": "1.0.0",
+          "definition": {
+            "name": "string",
+            "department": "string"
+          }
+        }
+      ]
     }
-  }
+  ]
 }

--- a/deployment/compose/setup/schema_registry/initial-schema.mq.json
+++ b/deployment/compose/setup/schema_registry/initial-schema.mq.json
@@ -1,60 +1,51 @@
 {
-  "schema_views": [
+  "schemas": [
     {
-      "view_id": "ec8cc976-412b-11eb-8000-000000000000",
-      "schema_id": "2cfad3c7-411a-11eb-8000-000000000000"
-    }
-  ],
-  "schema_definitions": [
-    {
-      "version": "1.0.0",
-      "definition_id": "2cfad4e7-411a-11eb-8001-000000000000",
-      "schema_id": "2cfad3c7-411a-11eb-8000-000000000000"
-    },
-    {
-      "version": "1.0.0",
-      "definition_id": "a5e0c96b-412c-11eb-8001-000000000000",
-      "schema_id": "a5e0c7e2-412c-11eb-8000-000000000000"
-    }
-  ],
-  "views": {
-    "ec8cc976-412b-11eb-8000-000000000000": {
-      "materializer_addr": "http://postgres_materializer:50203",
-      "name": "new view",
-      "materializer_options": {
-        "table": "MATERIALIZED_VIEW"
-      },
-      "fields": {
-        "foo": {
-          "FieldName": "a"
+      "id": "2cfad3c7-411a-11eb-8000-000000000000",
+      "type": "DocumentStorage",
+      "query_address": "http://postgres_query:50201",
+      "insert_destination": "cdl.document.1.data",
+      "name": "new schema",
+      "views": [
+        {
+          "id": "ec8cc976-412b-11eb-8000-000000000000",
+          "materializer_address": "http://postgres_materializer:50203",
+          "name": "new view",
+          "materializer_options": {
+            "table": "MATERIALIZED_VIEW"
+          },
+          "fields": {
+            "foo": {
+              "field_name": "a"
+            }
+          }
         }
-      }
-    }
-  },
-  "definitions": {
-    "a5e0c96b-412c-11eb-8001-000000000000": {
-      "definition": {
-        "b": "string"
-      }
+      ],
+      "definitions": [
+        {
+          "version": "1.0.0",
+          "definition": {
+            "a": "string"
+          }
+        }
+      ]
     },
-    "2cfad4e7-411a-11eb-8001-000000000000": {
-      "definition": {
-        "a": "number"
-      }
-    }
-  },
-  "schemas": {
-    "2cfad3c7-411a-11eb-8000-000000000000": {
-      "schema_type": "DocumentStorage",
+    {
+      "id": "a5e0c7e2-412c-11eb-8000-000000000000",
+      "type": "DocumentStorage",
       "query_address": "http://postgres_query:50201",
       "insert_destination": "cdl.document.1.data",
-      "name": "new schema"
-    },
-    "a5e0c7e2-412c-11eb-8000-000000000000": {
-      "schema_type": "DocumentStorage",
-      "query_address": "http://postgres_query:50201",
-      "insert_destination": "cdl.document.1.data",
-      "name": "second schema"
+      "name": "second schema",
+      "views": [],
+      "definitions": [
+        {
+          "version": "1.0.0",
+          "definition": {
+            "name": "string",
+            "department": "string"
+          }
+        }
+      ]
     }
-  }
+  ]
 }


### PR DESCRIPTION
Tested manually by requesting all schemas in graphQL in three different manual test scenarios:
* Kafka
* Rabbitmq
* GRpc

Other things than SR might not work (for example by lack of edge-registry or PUE in gRPC) but that's another issue.