### PR TITLE
feat: cdl view_id and relation_id

### DIFF
--- a/crates/api/src/schema/mutation.rs
+++ b/crates/api/src/schema/mutation.rs
@@ -60,12 +60,14 @@ impl MutationRoot {
         &self,
         context: &Context<'_>,
         schema_id: Uuid,
+        view_id: Option<Uuid>,
         new_view: NewView,
     ) -> FieldResult<View> {
         let mut conn = context.data_unchecked::<SchemaRegistryPool>().get().await?;
 
         let id = conn
             .add_view_to_schema(rpc::schema_registry::NewView {
+                view_id: view_id.map(|view_id| view_id.to_string()),
                 base_schema_id: schema_id.to_string(),
                 name: new_view.name.clone(),
                 materializer_address: new_view.materializer_address.clone(),

--- a/crates/api/src/schema/mutation.rs
+++ b/crates/api/src/schema/mutation.rs
@@ -196,12 +196,14 @@ impl MutationRoot {
     async fn add_relation(
         &self,
         context: &Context<'_>,
+        relation_id: Option<Uuid>,
         parent_schema_id: Uuid,
         child_schema_id: Uuid,
     ) -> FieldResult<Uuid> {
         let mut conn = context.data_unchecked::<EdgeRegistryPool>().get().await?;
         Ok(conn
-            .add_relation(rpc::edge_registry::SchemaRelation {
+            .add_relation(rpc::edge_registry::AddSchemaRelation {
+                relation_id: relation_id.map(|relation_id| relation_id.to_string()),
                 parent_schema_id: parent_schema_id.to_string(),
                 child_schema_id: child_schema_id.to_string(),
             })

--- a/crates/cdl-cli/src/actions/view.rs
+++ b/crates/cdl-cli/src/actions/view.rs
@@ -25,6 +25,7 @@ pub async fn get_view(view_id: Uuid, registry_addr: String) -> anyhow::Result<()
 
 #[allow(clippy::clippy::too_many_arguments)]
 pub async fn add_view_to_schema(
+    view_id: Option<Uuid>,
     base_schema_id: Uuid,
     name: String,
     materializer_address: String,
@@ -41,6 +42,7 @@ pub async fn add_view_to_schema(
     let relations: Vec<Relation> = serde_json::from_value(read_json(relations)?)?;
 
     let view = NewView {
+        view_id: view_id.map(|view_id| view_id.to_string()),
         base_schema_id: base_schema_id.to_string(),
         name: name.clone(),
         materializer_address,

--- a/crates/cdl-cli/src/args.rs
+++ b/crates/cdl-cli/src/args.rs
@@ -154,6 +154,9 @@ pub enum ViewAction {
 
     /// Add a new view to a schema in the registry.
     Add {
+        /// Id of view to add.
+        #[clap(short, long)]
+        view_id: Option<Uuid>,
         /// The id of the schema.
         #[clap(short, long)]
         schema_id: Uuid,

--- a/crates/cdl-cli/src/main.rs
+++ b/crates/cdl-cli/src/main.rs
@@ -67,6 +67,7 @@ pub async fn main() -> anyhow::Result<()> {
             }
             ViewAction::Get { id } => get_view(id, args.registry_addr).await,
             ViewAction::Add {
+                view_id,
                 schema_id,
                 name,
                 materializer_address,
@@ -76,6 +77,7 @@ pub async fn main() -> anyhow::Result<()> {
                 relations,
             } => {
                 add_view_to_schema(
+                    view_id,
                     schema_id,
                     name,
                     materializer_address,

--- a/crates/edge-registry/src/lib.rs
+++ b/crates/edge-registry/src/lib.rs
@@ -10,9 +10,9 @@ use itertools::Itertools;
 use metrics_utils::{self as metrics, counter};
 use rpc::edge_registry::edge_registry_server::EdgeRegistry;
 use rpc::edge_registry::{
-    Edge, Empty, ObjectIdQuery, ObjectRelations, RelationDetails, RelationId, RelationIdQuery,
-    RelationList, RelationQuery, RelationResponse, SchemaId, SchemaRelation, TreeObject, TreeQuery,
-    TreeResponse, ValidateRelationQuery,
+    AddSchemaRelation, Edge, Empty, ObjectIdQuery, ObjectRelations, RelationDetails, RelationId,
+    RelationIdQuery, RelationList, RelationQuery, RelationResponse, SchemaId, SchemaRelation,
+    TreeObject, TreeQuery, TreeResponse, ValidateRelationQuery,
 };
 use serde::{Deserialize, Serialize};
 use settings_utils::PostgresSettings;
@@ -105,6 +105,7 @@ impl EdgeRegistryImpl {
     #[tracing::instrument(skip(self))]
     async fn add_relation_impl(
         &self,
+        relation_id: Option<Uuid>,
         parent_schema_id: Uuid,
         child_schema_id: Uuid,
     ) -> anyhow::Result<Uuid> {
@@ -112,14 +113,27 @@ impl EdgeRegistryImpl {
 
         let conn = self.connect().await?;
 
-        let row = conn
-            .query(
-                "INSERT INTO relations (parent_schema_id, child_schema_id) VALUES ($1::uuid, $2::uuid) RETURNING id",
-                &[&parent_schema_id, &child_schema_id]
-            )
-            .await?;
+        let relation = if let Some(relation_id) = relation_id {
+            conn
+                .query(
+                    "INSERT INTO relations (relation_id, parent_schema_id, child_schema_id) VALUES ($1::uuid, $2::uuid, $3::uuid)",
+                    &[&parent_schema_id, &child_schema_id]
+                )
+                .await?;
 
-        Ok(row.get(0).context("Critical error, missing rows")?.get(0))
+            relation_id
+        } else {
+            let row = conn
+                .query(
+                    "INSERT INTO relations (parent_schema_id, child_schema_id) VALUES ($1::uuid, $2::uuid) RETURNING id",
+                    &[&parent_schema_id, &child_schema_id]
+                )
+                .await?;
+
+            row.get(0).context("Critical error, missing rows")?.get(0)
+        };
+
+        Ok(relation)
     }
 
     #[tracing::instrument(skip(self))]
@@ -417,23 +431,31 @@ fn intersect<T: PartialEq + Clone>(left: &[T], right: &[T]) -> Vec<T> {
 impl EdgeRegistry for EdgeRegistryImpl {
     async fn add_relation(
         &self,
-        request: Request<SchemaRelation>,
+        request: Request<AddSchemaRelation>,
     ) -> Result<Response<RelationId>, Status> {
         let request = request.into_inner();
 
         trace!(
-            "Received `add_relation` message with parent_id `{}` and child_id `{}`",
+            "Received `add_relation` message with parent_id `{}` and child_id `{}` and relation_id `{:?}`",
             request.parent_schema_id,
-            request.child_schema_id
+            request.child_schema_id,
+            request.relation_id,
         );
 
+        let relation_id = request
+            .relation_id
+            .as_ref()
+            .map(|relation_id| {
+                Uuid::from_str(&relation_id).map_err(|_| Status::invalid_argument("relation_id"))
+            })
+            .transpose()?;
         let parent_schema_id = Uuid::from_str(&request.parent_schema_id)
             .map_err(|_| Status::invalid_argument("parent_schema_id"))?;
         let child_schema_id = Uuid::from_str(&request.child_schema_id)
             .map_err(|_| Status::invalid_argument("child_schema_id"))?;
 
         let relation_id = self
-            .add_relation_impl(parent_schema_id, child_schema_id)
+            .add_relation_impl(relation_id, parent_schema_id, child_schema_id)
             .await
             .map_err(|err| db_communication_error("add_relation", err))?;
 

--- a/crates/rpc/proto/edge_registry.proto
+++ b/crates/rpc/proto/edge_registry.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 package edge_registry;
 
 service EdgeRegistry {
-  rpc AddRelation(SchemaRelation) returns (RelationId);
+  rpc AddRelation(AddSchemaRelation) returns (RelationId);
   rpc GetRelation(RelationQuery) returns (RelationResponse);
   rpc GetSchemaByRelation(RelationId) returns (SchemaRelation);
   rpc GetSchemaRelations(SchemaId) returns (RelationList);
@@ -33,6 +33,12 @@ message TreeObject {
   required string relation_id = 2;
   repeated string children = 3;
   repeated TreeResponse subtrees = 4;
+}
+
+message AddSchemaRelation {
+  optional string relation_id = 1;
+  required string parent_schema_id = 2;
+  required string child_schema_id = 3;
 }
 
 message SchemaRelation {

--- a/crates/rpc/proto/schema_registry.proto
+++ b/crates/rpc/proto/schema_registry.proto
@@ -153,13 +153,14 @@ message FullView {
 }
 
 message NewView {
-    required string base_schema_id = 1;
-    required string name = 2;
-    required string materializer_address = 3;
-    required string materializer_options = 4;
-    map<string, string> fields = 5;
-    optional Filter filters = 6;
-    repeated Relation relations = 7;
+    optional string view_id = 1;
+    required string base_schema_id = 2;
+    required string name = 3;
+    required string materializer_address = 4;
+    required string materializer_options = 5;
+    map<string, string> fields = 6;
+    optional Filter filters = 7;
+    repeated Relation relations = 8;
 }
 
 message Relation {

--- a/crates/rpc/src/codegen/edge_registry.rs
+++ b/crates/rpc/src/codegen/edge_registry.rs
@@ -24,6 +24,15 @@ pub struct TreeObject {
     pub subtrees: ::prost::alloc::vec::Vec<TreeResponse>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddSchemaRelation {
+    #[prost(string, optional, tag = "1")]
+    pub relation_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, required, tag = "2")]
+    pub parent_schema_id: ::prost::alloc::string::String,
+    #[prost(string, required, tag = "3")]
+    pub child_schema_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SchemaRelation {
     #[prost(string, required, tag = "1")]
     pub parent_schema_id: ::prost::alloc::string::String,
@@ -134,7 +143,7 @@ pub mod edge_registry_client {
         }
         pub async fn add_relation(
             &mut self,
-            request: impl tonic::IntoRequest<super::SchemaRelation>,
+            request: impl tonic::IntoRequest<super::AddSchemaRelation>,
         ) -> Result<tonic::Response<super::RelationId>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
@@ -320,7 +329,7 @@ pub mod edge_registry_server {
     pub trait EdgeRegistry: Send + Sync + 'static {
         async fn add_relation(
             &self,
-            request: tonic::Request<super::SchemaRelation>,
+            request: tonic::Request<super::AddSchemaRelation>,
         ) -> Result<tonic::Response<super::RelationId>, tonic::Status>;
         async fn get_relation(
             &self,
@@ -398,12 +407,12 @@ pub mod edge_registry_server {
                 "/edge_registry.EdgeRegistry/AddRelation" => {
                     #[allow(non_camel_case_types)]
                     struct AddRelationSvc<T: EdgeRegistry>(pub Arc<T>);
-                    impl<T: EdgeRegistry> tonic::server::UnaryService<super::SchemaRelation> for AddRelationSvc<T> {
+                    impl<T: EdgeRegistry> tonic::server::UnaryService<super::AddSchemaRelation> for AddRelationSvc<T> {
                         type Response = super::RelationId;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::SchemaRelation>,
+                            request: tonic::Request<super::AddSchemaRelation>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).add_relation(request).await };

--- a/crates/rpc/src/codegen/schema_registry.rs
+++ b/crates/rpc/src/codegen/schema_registry.rs
@@ -213,20 +213,22 @@ pub struct FullView {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewView {
-    #[prost(string, required, tag = "1")]
-    pub base_schema_id: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "1")]
+    pub view_id: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, required, tag = "2")]
-    pub name: ::prost::alloc::string::String,
+    pub base_schema_id: ::prost::alloc::string::String,
     #[prost(string, required, tag = "3")]
-    pub materializer_address: ::prost::alloc::string::String,
+    pub name: ::prost::alloc::string::String,
     #[prost(string, required, tag = "4")]
+    pub materializer_address: ::prost::alloc::string::String,
+    #[prost(string, required, tag = "5")]
     pub materializer_options: ::prost::alloc::string::String,
-    #[prost(map = "string, string", tag = "5")]
+    #[prost(map = "string, string", tag = "6")]
     pub fields:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag = "7")]
     pub filters: ::core::option::Option<Filter>,
-    #[prost(message, repeated, tag = "7")]
+    #[prost(message, repeated, tag = "8")]
     pub relations: ::prost::alloc::vec::Vec<Relation>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/schema-registry/src/db.rs
+++ b/crates/schema-registry/src/db.rs
@@ -377,7 +377,7 @@ impl SchemaRegistryDb {
     #[tracing::instrument(skip(self))]
     pub async fn add_view_to_schema(&self, new_view: NewView) -> RegistryResult<Uuid> {
         let mut conn = self.connect().await?;
-        let new_id = Uuid::new_v4();
+        let new_id = new_view.view_id.unwrap_or_else(Uuid::new_v4);
 
         sqlx::query!(
             "INSERT INTO views(id, base_schema, name, materializer_address, materializer_options, fields, filters, relations)

--- a/crates/schema-registry/src/rpc.rs
+++ b/crates/schema-registry/src/rpc.rs
@@ -215,6 +215,11 @@ impl SchemaRegistry for SchemaRegistryImpl {
         tracing::debug!(options = ?materializer_options, "Materializer options");
 
         let new_view = NewView {
+            view_id: request
+                .view_id
+                .as_ref()
+                .map(|view_id| parse_uuid(&view_id))
+                .transpose()?,
             base_schema_id: parse_uuid(&request.base_schema_id)?,
             name: request.name,
             materializer_address: request.materializer_address,

--- a/crates/schema-registry/src/types/view.rs
+++ b/crates/schema-registry/src/types/view.rs
@@ -35,6 +35,7 @@ pub struct View {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NewView {
+    pub view_id: Option<Uuid>,
     pub base_schema_id: Uuid,
     pub name: String,
     pub materializer_address: String,


### PR DESCRIPTION
Allow to specify view_id and relation_id explicitly when adding new entities to db