### PR TITLE
chore: use cache instead of retrieving from SR per request

### DIFF
--- a/crates/data-router/src/handler.rs
+++ b/crates/data-router/src/handler.rs
@@ -125,18 +125,13 @@ async fn route(
         data: event.data,
     };
 
-    let mut conn = rpc::schema_registry::connect(schema_registry_addr.to_owned()).await?;
-    let schema = conn
-        .get_schema_metadata(rpc::schema_registry::Id {
-            id: event.schema_id.to_string(),
-        })
-        .await
-        .context("failed to get schema metadata")?
-        .into_inner();
+    let insert_destination =
+        crate::schema::get_schema_insert_destination(cache, event.schema_id, schema_registry_addr)
+            .await?;
 
     send_message(
         producer,
-        &schema.insert_destination,
+        &insert_destination,
         message_key,
         serde_json::to_vec(&payload)?,
     )

--- a/crates/data-router/src/schema.rs
+++ b/crates/data-router/src/schema.rs
@@ -24,7 +24,7 @@ pub async fn get_schema_insert_destination(
     }
 
     let mut client = rpc::schema_registry::connect(schema_addr.to_owned()).await?;
-    let channel = client
+    let insert_destination = client
         .get_schema_metadata(Id {
             id: schema_id.to_string(),
         })
@@ -39,7 +39,7 @@ pub async fn get_schema_insert_destination(
     cache
         .lock()
         .unwrap_or_else(abort_on_poison)
-        .insert(schema_id, channel.clone());
+        .insert(schema_id, insert_destination.clone());
 
-    Ok(channel)
+    Ok(insert_destination)
 }

--- a/crates/data-router/src/schema.rs
+++ b/crates/data-router/src/schema.rs
@@ -13,14 +13,14 @@ pub async fn get_schema_insert_destination(
     schema_id: Uuid,
     schema_addr: &str,
 ) -> anyhow::Result<String> {
-    let recv_channel = cache
+    let destination = cache
         .lock()
         .unwrap_or_else(abort_on_poison)
         .get_mut(&schema_id)
         .cloned();
-    if let Some(val) = recv_channel {
+    if let Some(dest) = destination {
         trace!("Retrieved insert destination for {} from cache", schema_id);
-        return Ok(val);
+        return Ok(dest);
     }
 
     let mut client = rpc::schema_registry::connect(schema_addr.to_owned()).await?;


### PR DESCRIPTION
This is in place of https://github.com/epiphany-platform/CommonDataLayer/pull/520, which removed the unused cache.