### PR TITLE
chore: feature list update

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -40,12 +40,10 @@
 | CDLF-00016-00 | Schema-Registry-less CDL deployment      | Ready      | 1.0.0       | [RFC](../rfc/CDLF-00016-00-rfc-01.md) |
 | CDLF-00017-00 | Materialization - Computation            | TechSpec   | -----       |                                       |
 | CDLF-00018-00 | Materialization - Materialized Types     | TechSpec   | -----       |                                       |
-| CDLF-00019-00 | Materializer - OnDemand                  | Ready      | 1.0.0       | N/A                                   |
-| CDLF-0001A-00 | Materializer - General                   | Ready      | 1.0.0       | N/A                                   |
-| CDLF-0001B-00 | Materialization - Notifications          | Ready      | 1.0.0       | N/A                                   |
-| CDLF-0001C-00 | Object-side configuration                | Suggestion | -----       |                                       |
-| CDLF-0001D-00 | CIM Object Valdiation                    | Suggestion | -----       |                                       |
-| CDLF-0001E-00 | Materialization - Relationships          | Idea       | -----       |                                       |
+| CDLF-00019-00 | Materialization - Notifications          | Ready      | 1.0.0       | N/A                                   |
+| CDLF-0001A-00 | Object-side configuration                | Suggestion | -----       |                                       |
+| CDLF-0001B-00 | CIM Object Valdiation                    | Suggestion | -----       |                                       |
+| CDLF-0001C-00 | Materialization - Relationships          | Idea       | -----       |                                       |
 
 ## References:
 [CDL RFC directory](https://github.com/epiphany-platform/CommonDataLayer/tree/develop/docs/rfc)


### PR DESCRIPTION
continuation of #596

Introducing materializers isn't a feature on its own, it's part of CDLF-00013-00 Materialized views.
- described in the same RFC as materialized views
- materializers without materialization don't provide any value to a client(or CDL internals), the same goes for the other way around(materialization with no materializers - CDL will report errors). There is no known use case for materialization without any materializers nor for materializers without materialization.