### PR TITLE
chore: add group_imports = 'StdExternalCrate' to rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+group_imports = "StdExternalCrate"

--- a/benchmarking/src/upload_to_kafka.rs
+++ b/benchmarking/src/upload_to_kafka.rs
@@ -1,3 +1,7 @@
+use std::io::Stdout;
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::Context;
 use clap::Clap;
 use pbr::ProgressBar;
@@ -5,9 +9,6 @@ use rdkafka::{
     producer::{FutureProducer, FutureRecord},
     ClientConfig,
 };
-use std::io::Stdout;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::Mutex;
 use tokio::time::sleep;

--- a/benchmarking/src/upload_to_rabbitmq.rs
+++ b/benchmarking/src/upload_to_rabbitmq.rs
@@ -1,12 +1,13 @@
+use std::io::Stdout;
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::Context;
 use clap::Clap;
 use lapin::{
     options::BasicPublishOptions, BasicProperties, Channel, Connection, ConnectionProperties,
 };
 use pbr::ProgressBar;
-use std::io::Stdout;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::Mutex;
 use tokio::time::sleep;

--- a/benchmarking/src/utils.rs
+++ b/benchmarking/src/utils.rs
@@ -1,8 +1,9 @@
+use std::io::Stdout;
+
 use anyhow::Context;
 use pbr::ProgressBar;
 use serde::Serialize;
 use serde_json::Value;
-use std::io::Stdout;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 

--- a/crates/api/src/events.rs
+++ b/crates/api/src/events.rs
@@ -7,16 +7,16 @@ use std::pin::Pin;
 
 use async_graphql::FieldResult;
 use async_trait::async_trait;
-use futures::task::{Context as FutCtx, Poll};
-use futures::{Future, Stream};
-use tokio::sync::broadcast::{self, Sender};
-
-use crate::settings::Settings;
 use communication_utils::{
     consumer::{CommonConsumer, CommonConsumerConfig, ConsumerHandler},
     message::CommunicationMessage,
 };
+use futures::task::{Context as FutCtx, Poll};
+use futures::{Future, Stream};
 use settings_utils::CommunicationMethod;
+use tokio::sync::broadcast::{self, Sender};
+
+use crate::settings::Settings;
 
 /// Owned generic message received from message queue.
 #[derive(Clone, Debug)]

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,17 +1,16 @@
 use std::convert::Infallible;
 
+use api::schema::context::MQEvents;
+use api::schema::{mutation::MutationRoot, query::QueryRoot, subscription::SubscriptionRoot};
+use api::settings::Settings;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::Schema;
 use async_graphql_warp::{graphql_subscription, Response};
 use rpc::edge_registry::EdgeRegistryConnectionManager;
 use rpc::materializer_ondemand::OnDemandMaterializerConnectionManager;
 use rpc::schema_registry::SchemaRegistryConnectionManager;
-use warp::{http::Response as HttpResponse, hyper::header::CONTENT_TYPE, hyper::Method, Filter};
-
-use api::schema::context::MQEvents;
-use api::schema::{mutation::MutationRoot, query::QueryRoot, subscription::SubscriptionRoot};
-use api::settings::Settings;
 use settings_utils::load_settings;
+use warp::{http::Response as HttpResponse, hyper::header::CONTENT_TYPE, hyper::Method, Filter};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/api/src/schema/context.rs
+++ b/crates/api/src/schema/context.rs
@@ -1,7 +1,9 @@
-use crate::{events::EventStream, events::EventSubscriber, settings::Settings};
 use std::collections::HashMap;
 use std::sync::Arc;
+
 use tokio::sync::Mutex;
+
+use crate::{events::EventStream, events::EventSubscriber, settings::Settings};
 
 #[derive(Clone)]
 pub struct MQEvents {

--- a/crates/api/src/schema/mutation.rs
+++ b/crates/api/src/schema/mutation.rs
@@ -1,9 +1,3 @@
-use crate::schema::utils::{get_schema, get_view};
-use crate::types::data::{InputMessage, ObjectRelations};
-use crate::types::schema::{Definition, FullSchema, NewSchema, NewVersion, UpdateSchema};
-use crate::types::view::{NewView, View, ViewUpdate};
-use crate::{error::Error, settings::Settings};
-use crate::{types::view::FullView, types::IntoQueried};
 use async_graphql::{Context, FieldResult, Object};
 use cdl_dto::ingestion::OwnedInsertMessage;
 use cdl_dto::TryIntoRpc;
@@ -12,6 +6,13 @@ use rpc::edge_registry::EdgeRegistryPool;
 use rpc::schema_registry::SchemaRegistryPool;
 use serde_json::value::to_raw_value;
 use uuid::Uuid;
+
+use crate::schema::utils::{get_schema, get_view};
+use crate::types::data::{InputMessage, ObjectRelations};
+use crate::types::schema::{Definition, FullSchema, NewSchema, NewVersion, UpdateSchema};
+use crate::types::view::{NewView, View, ViewUpdate};
+use crate::{error::Error, settings::Settings};
+use crate::{types::view::FullView, types::IntoQueried};
 
 pub struct MutationRoot;
 

--- a/crates/api/src/schema/query.rs
+++ b/crates/api/src/schema/query.rs
@@ -2,7 +2,12 @@ use std::collections::HashMap;
 
 use async_graphql::{Context, FieldResult, Json, Object};
 use itertools::Itertools;
+use rpc::edge_registry::EdgeRegistryPool;
+use rpc::materializer_ondemand::{OnDemandMaterializerPool, OnDemandRequest};
+use rpc::schema_registry::types::SchemaType;
+use rpc::schema_registry::SchemaRegistryPool;
 use semver::VersionReq;
+use tracing_utils::http::RequestBuilderTracingExt;
 use uuid::Uuid;
 
 use crate::schema::utils::{get_schema, get_view};
@@ -12,11 +17,6 @@ use crate::types::view::View;
 use crate::types::view::{MaterializedView, RowDefinition};
 use crate::{error::Result, types::view::FullView};
 use crate::{settings::Settings, types::view::OnDemandViewRequest};
-use rpc::edge_registry::EdgeRegistryPool;
-use rpc::materializer_ondemand::{OnDemandMaterializerPool, OnDemandRequest};
-use rpc::schema_registry::types::SchemaType;
-use rpc::schema_registry::SchemaRegistryPool;
-use tracing_utils::http::RequestBuilderTracingExt;
 
 #[Object]
 /// Schema is the format in which data is to be sent to the Common Data Layer.

--- a/crates/api/src/schema/utils.rs
+++ b/crates/api/src/schema/utils.rs
@@ -1,8 +1,9 @@
-use crate::types::schema::FullSchema;
-use crate::types::view::FullView;
 use async_graphql::FieldResult;
 use rpc::schema_registry::SchemaRegistryConn;
 use uuid::Uuid;
+
+use crate::types::schema::FullSchema;
+use crate::types::view::FullView;
 
 pub async fn get_view(conn: &mut SchemaRegistryConn, id: Uuid) -> FieldResult<FullView> {
     tracing::debug!("get view: {:?}", id);

--- a/crates/api/src/types/schema.rs
+++ b/crates/api/src/types/schema.rs
@@ -1,12 +1,12 @@
 use std::convert::TryInto;
 
 use async_graphql::{FieldResult, InputObject, Json, SimpleObject};
+use rpc::schema_registry::types::SchemaType;
 use semver::{Version, VersionReq};
 use serde_json::Value;
 use uuid::Uuid;
 
 use crate::types::view::View;
-use rpc::schema_registry::types::SchemaType;
 
 pub struct FullSchema {
     pub id: Uuid,

--- a/crates/api/src/types/view/input.rs
+++ b/crates/api/src/types/view/input.rs
@@ -1,14 +1,13 @@
 use std::{collections::HashMap, num::NonZeroU8};
 
 use async_graphql::{FieldResult, InputObject, Json};
+use cdl_dto::materialization::{Filter, Relation};
+use cdl_dto::TryIntoRpc;
 use rpc::schema_registry::types::SearchFor;
 use serde_json::Value;
 use uuid::Uuid;
 
 use crate::types::IntoQueried;
-
-use cdl_dto::materialization::{Filter, Relation};
-use cdl_dto::TryIntoRpc;
 
 /// A new view under a schema.
 #[derive(Clone, Debug, InputObject)]

--- a/crates/api/src/types/view/queried.rs
+++ b/crates/api/src/types/view/queried.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use async_graphql::{FieldResult, Json, SimpleObject};
-use serde_json::Value;
-use uuid::Uuid;
-
 use cdl_dto::materialization::{Filter, Relation};
 use cdl_dto::TryFromRpc;
+use serde_json::Value;
+use uuid::Uuid;
 
 /// A view under a schema.
 #[derive(Debug, SimpleObject)]

--- a/crates/cdl-cli/src/actions/schema.rs
+++ b/crates/cdl-cli/src/actions/schema.rs
@@ -1,15 +1,15 @@
 use std::convert::TryInto;
 use std::path::PathBuf;
 
+use rpc::schema_registry::{
+    types::SchemaType, Empty, Id, NewSchema, NewSchemaVersion, SchemaDefinition, SchemaMetadata,
+    SchemaMetadataPatch, SchemaMetadataUpdate, ValueToValidate, VersionedId,
+};
 use semver::{Version, VersionReq};
 use serde_json::Value;
 use uuid::Uuid;
 
 use crate::utils::*;
-use rpc::schema_registry::{
-    types::SchemaType, Empty, Id, NewSchema, NewSchemaVersion, SchemaDefinition, SchemaMetadata,
-    SchemaMetadataPatch, SchemaMetadataUpdate, ValueToValidate, VersionedId,
-};
 
 pub async fn get_schema_definition(
     schema_id: Uuid,

--- a/crates/cdl-cli/src/args.rs
+++ b/crates/cdl-cli/src/args.rs
@@ -1,10 +1,9 @@
 use std::path::PathBuf;
 
 use clap::Clap;
+use rpc::schema_registry::types::SchemaType;
 use semver::{Version, VersionReq};
 use uuid::Uuid;
-
-use rpc::schema_registry::types::SchemaType;
 
 /// A tool to interact with services in the Common Data Layer.
 #[derive(Clap)]

--- a/crates/cdl-cli/src/utils.rs
+++ b/crates/cdl-cli/src/utils.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::Context;
 use serde_json::Value;
-use std::path::PathBuf;
 
 pub fn read_json(file: Option<PathBuf>) -> anyhow::Result<Value> {
     if let Some(file_name) = file {

--- a/crates/command-service/src/communication/mod.rs
+++ b/crates/command-service/src/communication/mod.rs
@@ -1,10 +1,12 @@
-use crate::communication::resolution::Resolution;
-use crate::output::OutputPlugin;
+use std::sync::Arc;
+
 use cdl_dto::ingestion::{BorrowedInsertMessage, OwnedInsertMessage};
 use metrics_utils::*;
-use std::sync::Arc;
 use tracing::trace;
 use utils::notification::NotificationPublisher;
+
+use crate::communication::resolution::Resolution;
+use crate::output::OutputPlugin;
 
 pub mod config;
 pub mod resolution;

--- a/crates/command-service/src/input/service/mod.rs
+++ b/crates/command-service/src/input/service/mod.rs
@@ -1,5 +1,5 @@
-use crate::output::OutputPlugin;
-use crate::{communication::MessageRouter, input::Error};
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use cdl_dto::ingestion::BorrowedInsertMessage;
 use communication_utils::get_order_group_id;
@@ -9,9 +9,11 @@ use communication_utils::{
 use communication_utils::{parallel_consumer::ParallelCommonConsumer, Result};
 use futures::future::try_join_all;
 use metrics_utils::{self as metrics, counter};
-use std::sync::Arc;
 use tracing::{error, trace};
 use utils::parallel_task_queue::ParallelTaskQueue;
+
+use crate::output::OutputPlugin;
+use crate::{communication::MessageRouter, input::Error};
 
 pub struct Service<P: OutputPlugin> {
     consumers: Vec<ParallelCommonConsumer>,

--- a/crates/command-service/src/output/druid/mod.rs
+++ b/crates/command-service/src/output/druid/mod.rs
@@ -1,6 +1,5 @@
-use crate::communication::resolution::Resolution;
-use crate::output::OutputPlugin;
-use crate::settings::DruidSettings;
+use std::time::Duration;
+
 use anyhow::Context;
 use cdl_dto::ingestion::BorrowedInsertMessage;
 use futures::stream::{self, StreamExt};
@@ -9,9 +8,12 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::ClientConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::time::Duration;
 use tracing::error;
 use uuid::Uuid;
+
+use crate::communication::resolution::Resolution;
+use crate::output::OutputPlugin;
+use crate::settings::DruidSettings;
 
 #[derive(Deserialize)]
 struct TimeseriesInputMessage {

--- a/crates/command-service/src/output/mod.rs
+++ b/crates/command-service/src/output/mod.rs
@@ -1,8 +1,9 @@
-use crate::communication::resolution::Resolution;
 use cdl_dto::ingestion::BorrowedInsertMessage;
 pub use druid::DruidOutputPlugin;
 pub use psql::PostgresOutputPlugin;
 pub use victoria_metrics::VictoriaMetricsOutputPlugin;
+
+use crate::communication::resolution::Resolution;
 
 mod druid;
 mod psql;

--- a/crates/command-service/src/output/psql/mod.rs
+++ b/crates/command-service/src/output/psql/mod.rs
@@ -1,5 +1,5 @@
-use crate::communication::resolution::Resolution;
-use crate::output::OutputPlugin;
+use std::time;
+
 use bb8::Pool;
 use bb8_postgres::tokio_postgres::types::Json;
 use bb8_postgres::tokio_postgres::{Config, NoTls};
@@ -9,9 +9,11 @@ pub use error::Error;
 use metrics_utils::{self as metrics, counter};
 use serde_json::Value;
 use settings_utils::PostgresSettings;
-use std::time;
 use tracing::{error, trace};
 use utils::psql::validate_schema;
+
+use crate::communication::resolution::Resolution;
+use crate::output::OutputPlugin;
 
 pub mod error;
 

--- a/crates/command-service/src/output/victoria_metrics/mod.rs
+++ b/crates/command-service/src/output/victoria_metrics/mod.rs
@@ -1,5 +1,3 @@
-use crate::communication::resolution::Resolution;
-use crate::output::OutputPlugin;
 use cdl_dto::ingestion::BorrowedInsertMessage;
 use fnv::FnvHashMap;
 use metrics_utils::{self as metrics, counter};
@@ -13,6 +11,9 @@ use thiserror::Error as DeriveError;
 use tracing::error;
 use url::ParseError;
 use uuid::Uuid;
+
+use crate::communication::resolution::Resolution;
+use crate::output::OutputPlugin;
 
 pub struct VictoriaMetricsOutputPlugin {
     client: Client,
@@ -148,9 +149,10 @@ mod tests {
     use super::*;
 
     mod describe_build_line_protocol {
-        use super::*;
         use test_case::test_case;
         use uuid::Uuid;
+
+        use super::*;
 
         #[test_case(r#"[{"fields":{}, "ts": 15},
                        {"fields":{"a01": 10}, "ts": 15}]"#                => matches Err(Error::EmptyFields))]

--- a/crates/data-router/src/config.rs
+++ b/crates/data-router/src/config.rs
@@ -1,11 +1,11 @@
-use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use communication_utils::{parallel_consumer::ParallelCommonConsumer, publisher::CommonPublisher};
+use serde::{Deserialize, Serialize};
 use settings_utils::{
     AmqpSettings, ConsumerKafkaSettings, GRpcSettings, LogSettings, MonitoringSettings,
     RepositoryStaticRouting,
 };
-use std::collections::HashMap;
 use task_utils::task_limiter::TaskLimiter;
 
 #[derive(Deserialize, Debug, Serialize)]

--- a/crates/data-router/src/handler.rs
+++ b/crates/data-router/src/handler.rs
@@ -1,4 +1,6 @@
-use crate::schema::SchemaCache;
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use anyhow::{bail, Context};
 use async_trait::async_trait;
 use cdl_dto::ingestion::{BorrowedInsertMessage, DataRouterInsertMessage};
@@ -11,10 +13,10 @@ use metrics_utils::{self as metrics, counter};
 use misc_utils::current_timestamp;
 use serde_json::Value;
 use settings_utils::RepositoryStaticRouting;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tracing::{error, trace};
 use utils::parallel_task_queue::ParallelTaskQueue;
+
+use crate::schema::SchemaCache;
 
 static CDL_INPUT_PROTOCOL_VERSION_MAJOR: u64 = 1;
 static CDL_INPUT_PROTOCOL_VERSION_MINOR: u64 = 0;

--- a/crates/data-router/src/main.rs
+++ b/crates/data-router/src/main.rs
@@ -1,12 +1,14 @@
 #![feature(exact_size_is_empty)]
 
-use crate::schema::SchemaMetadataSupplier;
-use crate::{config::Settings, handler::Handler};
+use std::sync::Arc;
+
 use cache::DynamicCache;
 use metrics_utils as metrics;
 use settings_utils::load_settings;
-use std::sync::Arc;
 use utils::parallel_task_queue::ParallelTaskQueue;
+
+use crate::schema::SchemaMetadataSupplier;
+use crate::{config::Settings, handler::Handler};
 
 mod config;
 mod handler;

--- a/crates/db-shrinker-postgres/src/main.rs
+++ b/crates/db-shrinker-postgres/src/main.rs
@@ -2,9 +2,8 @@ use anyhow::Context;
 use clap::Clap;
 use postgres::{Client, Config, NoTls, Row};
 use serde_json::Value as JsonValue;
-use uuid::Uuid;
-
 use tracing::{debug, info, trace};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Clap)]
 struct Opts {
@@ -135,9 +134,10 @@ fn merge(a: &mut JsonValue, b: JsonValue) {
 #[cfg(test)]
 mod tests {
     mod describe_merge {
-        use crate::merge;
         use serde_json::{json, Value};
         use test_case::test_case;
+
+        use crate::merge;
 
         #[test_case("{}", "{}" => json!({}))]
         #[test_case(r#"{"success": true}"#, "{}" => json!({"success": true}))]

--- a/crates/edge-registry/src/lib.rs
+++ b/crates/edge-registry/src/lib.rs
@@ -1,3 +1,9 @@
+use std::cmp::min;
+use std::convert::TryInto;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::{fmt, time};
+
 use anyhow::{Context, Error};
 use bb8_postgres::bb8::{Pool, PooledConnection};
 use bb8_postgres::tokio_postgres::{Config, NoTls};
@@ -16,11 +22,6 @@ use rpc::edge_registry::{
 };
 use serde::{Deserialize, Serialize};
 use settings_utils::PostgresSettings;
-use std::cmp::min;
-use std::convert::TryInto;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::{fmt, time};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};

--- a/crates/edge-registry/src/main.rs
+++ b/crates/edge-registry/src/main.rs
@@ -1,12 +1,13 @@
 #![feature(async_closure)]
 
+use std::process;
+use std::sync::Arc;
+
 use edge_registry::settings::Settings;
 use edge_registry::EdgeRegistryImpl;
 use metrics_utils as metrics;
 use rpc::edge_registry::edge_registry_server::EdgeRegistryServer;
 use settings_utils::{load_settings, CommunicationMethod};
-use std::process;
-use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::transport::Server;
 use tracing::{error, info};

--- a/crates/materializer-general/src/lib.rs
+++ b/crates/materializer-general/src/lib.rs
@@ -1,15 +1,17 @@
-use crate::view::ViewCache;
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use cache::DynamicCache;
 use plugins::{MaterializerPlugin, PostgresMaterializer};
 use rpc::materializer_general::{general_materializer_server::GeneralMaterializer, Empty, Options};
 use rpc::{common::RowDefinition, materializer_general::MaterializedView};
 use serde::Serialize;
 use settings_utils::PostgresSettings;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::Mutex;
 use utils::notification::{IntoSerialize, NotificationPublisher};
 use view::ViewSupplier;
+
+use crate::view::ViewCache;
 
 mod plugins;
 pub mod settings;

--- a/crates/materializer-general/src/main.rs
+++ b/crates/materializer-general/src/main.rs
@@ -1,9 +1,10 @@
 #![feature(async_closure)]
 
+use std::sync::Arc;
+
 use materializer_general::{settings::Settings, MaterializerImpl};
 use rpc::materializer_general::general_materializer_server::GeneralMaterializerServer;
 use settings_utils::load_settings;
-use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::transport::Server;
 

--- a/crates/materializer-general/src/plugins/postgres.rs
+++ b/crates/materializer-general/src/plugins/postgres.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
 use std::{collections::HashMap, convert::TryFrom, convert::TryInto};
 
-use super::MaterializerPlugin;
 use anyhow::Context;
 use bb8_postgres::tokio_postgres::{types::Type, Config, NoTls};
 use bb8_postgres::{bb8, PostgresConnectionManager};
@@ -17,6 +16,8 @@ use rpc::materializer_general::MaterializedView;
 use serde_json::Value;
 use settings_utils::PostgresSettings;
 use uuid::Uuid;
+
+use super::MaterializerPlugin;
 
 // TODO: Move some of those structs to dto crate
 

--- a/crates/object-builder/src/buffer_stream.rs
+++ b/crates/object-builder/src/buffer_stream.rs
@@ -1,13 +1,15 @@
+use std::task::Poll;
+
 use anyhow::Result;
 use futures::{ready, Stream};
 use pin_project_lite::pin_project;
 use serde_json::Value;
-use std::task::Poll;
 
 mod buffer;
 
-use crate::{sources::RowSource, view_plan::ViewPlan, ObjectIdPair};
 pub use buffer::ObjectBuffer;
+
+use crate::{sources::RowSource, view_plan::ViewPlan, ObjectIdPair};
 
 pin_project! {
     pub struct ObjectBufferedStream<S> {
@@ -70,12 +72,6 @@ where
 
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use crate::{
-        sources::FieldDefinitionSource,
-        view_plan::{UnfinishedRow, ViewPlan},
-    };
-
-    use super::*;
     use cdl_dto::materialization::{FieldDefinition, FieldType, FullView};
     use futures::{pin_mut, FutureExt, StreamExt, TryStreamExt};
     use maplit::*;
@@ -83,6 +79,12 @@ mod tests {
     use tokio::sync::mpsc::{channel, Sender};
     use tokio_stream::wrappers::ReceiverStream;
     use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        sources::FieldDefinitionSource,
+        view_plan::{UnfinishedRow, ViewPlan},
+    };
 
     impl<S> ObjectBufferedStream<S>
     where

--- a/crates/object-builder/src/row_builder/field_builder/computation.rs
+++ b/crates/object-builder/src/row_builder/field_builder/computation.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde_json::Value;
 
-use crate::{sources::ComputationSource, utils::get_sub_object, ObjectIdPair};
-
 use super::FieldBuilder;
+use crate::{sources::ComputationSource, utils::get_sub_object, ObjectIdPair};
 
 #[derive(Clone, Copy)]
 pub struct ComputationEngine<'a> {

--- a/crates/object-builder/src/row_builder/row_filter.rs
+++ b/crates/object-builder/src/row_builder/row_filter.rs
@@ -4,13 +4,12 @@ use anyhow::{Context, Result};
 use rpc::schema_registry::types::LogicOperator;
 use serde_json::Value;
 
+use super::field_builder::ComputationEngine;
 use crate::{
     sources::{FilterSource, FilterValueSource},
     utils::get_sub_object,
     ObjectIdPair, RowDefinition,
 };
-
-use super::field_builder::ComputationEngine;
 
 pub struct RowFilter<'a> {
     objects: &'a HashMap<ObjectIdPair, Value>,

--- a/crates/object-builder/src/sources.rs
+++ b/crates/object-builder/src/sources.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
+
 use cdl_dto::materialization::FieldType;
 use rpc::schema_registry::types::LogicOperator;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 
 use crate::ObjectIdPair;
 

--- a/crates/object-builder/src/view_plan.rs
+++ b/crates/object-builder/src/view_plan.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, num::NonZeroU8};
+
 use anyhow::Result;
 use cdl_dto::{
     edges::RelationTree,
@@ -6,13 +8,11 @@ use cdl_dto::{
 use itertools::Itertools;
 use serde::Serialize;
 use serde_json::Value;
-use std::{collections::HashMap, num::NonZeroU8};
 use uuid::Uuid;
 
+use self::builder::ViewPlanBuilder;
 use crate::sources::{FieldDefinitionSource, FilterSource, RowSource};
 use crate::ObjectIdPair;
-
-use self::builder::ViewPlanBuilder;
 
 mod builder;
 
@@ -120,9 +120,10 @@ impl ViewPlan {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use super::*;
     use anyhow::Result;
     use misc_utils::serde_json::{to_string_sorted, SortSettings};
+
+    use super::*;
 
     #[test]
     fn build_view_plan_test() -> Result<()> {

--- a/crates/object-builder/src/view_plan/builder.rs
+++ b/crates/object-builder/src/view_plan/builder.rs
@@ -1,4 +1,8 @@
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU8;
+
 use anyhow::{Context, Result};
+use cdl_dto::materialization::Relation;
 use cdl_dto::{
     edges::{RelationTree, TreeObject},
     materialization::{
@@ -7,10 +11,6 @@ use cdl_dto::{
         RawValueFilter, SchemaFieldFilter, SimpleFilter, SimpleFilterKind, ViewPathFilter,
     },
 };
-use std::collections::{HashMap, HashSet};
-use std::num::NonZeroU8;
-
-use cdl_dto::materialization::Relation;
 use uuid::Uuid;
 
 use super::{UnfinishedRow, UnfinishedRowVariant};

--- a/crates/partial-update-engine/src/main.rs
+++ b/crates/partial-update-engine/src/main.rs
@@ -1,3 +1,9 @@
+use std::collections::hash_map::Entry;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
+
 use anyhow::{Context, Result};
 use cdl_dto::materialization::Request;
 use misc_utils::set_aborting_panic_hook;
@@ -11,11 +17,6 @@ use rdkafka::{
 use rpc::schema_registry::{FullView, Id};
 use serde::{Deserialize, Serialize};
 use settings_utils::*;
-use std::collections::hash_map::Entry;
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
 use tracing::{trace, Instrument};

--- a/crates/query-router/src/handler.rs
+++ b/crates/query-router/src/handler.rs
@@ -1,15 +1,16 @@
+use std::{collections::HashMap, sync::Arc};
+
+use futures_util::TryStreamExt;
+use rpc::schema_registry::types::SchemaType;
+use rpc::{query_service, query_service_ts};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, sync::Arc};
+use settings_utils::RepositoryStaticRouting;
 use uuid::Uuid;
 use warp::hyper::header::CONTENT_TYPE;
 
 use crate::error::Error;
 use crate::schema::{SchemaCache, SchemaMetadata};
-use futures_util::TryStreamExt;
-use rpc::schema_registry::types::SchemaType;
-use rpc::{query_service, query_service_ts};
-use settings_utils::RepositoryStaticRouting;
 
 const APPLICATION_JSON: &str = "application/json";
 

--- a/crates/query-router/src/main.rs
+++ b/crates/query-router/src/main.rs
@@ -1,10 +1,11 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use cache::DynamicCache;
 use metrics_utils as metrics;
 use schema::SchemaMetadataSupplier;
 use serde::Deserialize;
 use settings_utils::{load_settings, LogSettings, MonitoringSettings, RepositoryStaticRouting};
-use std::collections::HashMap;
-use std::sync::Arc;
 use uuid::Uuid;
 use warp::Filter;
 

--- a/crates/query-router/src/schema.rs
+++ b/crates/query-router/src/schema.rs
@@ -1,6 +1,7 @@
+use std::convert::TryInto;
+
 use cache::{CacheSupplier, DynamicCache};
 use rpc::schema_registry::types::SchemaType;
-use std::convert::TryInto;
 use uuid::Uuid;
 
 pub type SchemaCache = DynamicCache<SchemaMetadataSupplier, Uuid, SchemaMetadata>;

--- a/crates/query-service-ts/src/main.rs
+++ b/crates/query-service-ts/src/main.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv4Addr, SocketAddrV4};
+
 use anyhow::Context;
 use metrics_utils as metrics;
 use query_service_ts::druid::{DruidQuery, DruidSettings};
@@ -5,7 +7,6 @@ use query_service_ts::victoria::VictoriaQuery;
 use rpc::query_service_ts::query_service_ts_server::{QueryServiceTs, QueryServiceTsServer};
 use serde::Deserialize;
 use settings_utils::*;
-use std::net::{Ipv4Addr, SocketAddrV4};
 use tonic::transport::Server;
 
 #[derive(Debug, Deserialize)]

--- a/crates/query-service/src/main.rs
+++ b/crates/query-service/src/main.rs
@@ -1,9 +1,10 @@
+use std::net::{Ipv4Addr, SocketAddrV4};
+
 use anyhow::Context;
 use metrics_utils as metrics;
 use rpc::query_service::query_service_server::{QueryService, QueryServiceServer};
 use serde::Deserialize;
 use settings_utils::*;
-use std::net::{Ipv4Addr, SocketAddrV4};
 use tonic::transport::Server;
 
 #[derive(Debug, Deserialize)]

--- a/crates/rpc/src/edge_registry.rs
+++ b/crates/rpc/src/edge_registry.rs
@@ -1,10 +1,11 @@
-pub use crate::codegen::edge_registry::*;
-use crate::error::ClientError;
 use bb8::{Pool, PooledConnection};
 use edge_registry_client::EdgeRegistryClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint, Error};
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::edge_registry::*;
+use crate::error::ClientError;
 
 pub type EdgeRegistryPool = Pool<EdgeRegistryConnectionManager>;
 pub type EdgeRegistryConn =

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,5 +1,4 @@
 use thiserror::Error as DeriveError;
-
 pub use tonic::{Code, Status};
 
 #[derive(Debug, DeriveError)]

--- a/crates/rpc/src/generic.rs
+++ b/crates/rpc/src/generic.rs
@@ -1,9 +1,10 @@
-pub use crate::codegen::generic_rpc::*;
-use crate::error::ClientError;
 use generic_rpc_client::GenericRpcClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::generic_rpc::*;
+use crate::error::ClientError;
 
 pub async fn connect(
     addr: String,

--- a/crates/rpc/src/materializer_general.rs
+++ b/crates/rpc/src/materializer_general.rs
@@ -1,9 +1,10 @@
-pub use crate::codegen::materializer_general::*;
-use crate::error::ClientError;
 use general_materializer_client::GeneralMaterializerClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::materializer_general::*;
+use crate::error::ClientError;
 
 pub async fn connect(
     addr: String,

--- a/crates/rpc/src/materializer_ondemand.rs
+++ b/crates/rpc/src/materializer_ondemand.rs
@@ -1,10 +1,11 @@
-pub use crate::codegen::materializer_ondemand::*;
-use crate::error::ClientError;
 use bb8::{Pool, PooledConnection};
 use on_demand_materializer_client::OnDemandMaterializerClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::materializer_ondemand::*;
+use crate::error::ClientError;
 
 pub type OnDemandMaterializerConn =
     OnDemandMaterializerClient<InterceptedService<Channel, &'static dyn InterceptorType>>;

--- a/crates/rpc/src/object_builder.rs
+++ b/crates/rpc/src/object_builder.rs
@@ -1,9 +1,10 @@
-pub use crate::codegen::object_builder::*;
-use crate::error::ClientError;
 use object_builder_client::ObjectBuilderClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::object_builder::*;
+use crate::error::ClientError;
 
 pub async fn connect(
     addr: impl Into<String>,

--- a/crates/rpc/src/query_service.rs
+++ b/crates/rpc/src/query_service.rs
@@ -1,11 +1,13 @@
-pub use crate::codegen::query_service::*;
-use crate::error::ClientError;
+use std::pin::Pin;
+
 use futures_util::{Stream, TryStreamExt};
 use query_service_client::QueryServiceClient;
-use std::pin::Pin;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint, Error};
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::query_service::*;
+use crate::error::ClientError;
 
 pub type ObjectStream<Error = ClientError> =
     Pin<Box<dyn Stream<Item = Result<Object, Error>> + Send + Sync + 'static>>;

--- a/crates/rpc/src/query_service_ts.rs
+++ b/crates/rpc/src/query_service_ts.rs
@@ -1,9 +1,10 @@
-pub use crate::codegen::query_service_ts::*;
-use crate::error::ClientError;
 use query_service_ts_client::QueryServiceTsClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint, Error};
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::query_service_ts::*;
+use crate::error::ClientError;
 
 pub async fn connect(
     addr: String,

--- a/crates/rpc/src/schema_registry.rs
+++ b/crates/rpc/src/schema_registry.rs
@@ -1,10 +1,11 @@
-pub use crate::codegen::schema_registry::*;
-use crate::error::ClientError;
 use bb8::{Pool, PooledConnection};
 use schema_registry_client::SchemaRegistryClient;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tracing_utils::grpc::InterceptorType;
+
+pub use crate::codegen::schema_registry::*;
+use crate::error::ClientError;
 
 pub mod types;
 

--- a/crates/schema-registry/src/db.rs
+++ b/crates/schema-registry/src/db.rs
@@ -1,5 +1,9 @@
 use std::collections::HashMap;
 
+use cdl_dto::materialization::{FieldDefinition, Filter, Relation};
+use either::Either;
+use futures::future;
+use futures_util::stream::{StreamExt, TryStreamExt};
 use semver::Version;
 use serde_json::Value;
 use sqlx::pool::PoolConnection;
@@ -17,10 +21,6 @@ use crate::types::DbExport;
 use crate::types::VersionedUuid;
 use crate::utils::build_full_schema;
 use crate::{settings::Settings, types::view::FullView};
-use cdl_dto::materialization::{FieldDefinition, Filter, Relation};
-use either::Either;
-use futures::future;
-use futures_util::stream::{StreamExt, TryStreamExt};
 
 const SCHEMAS_LISTEN_CHANNEL: &str = "schemas";
 const VIEWS_LISTEN_CHANNEL: &str = "views";

--- a/crates/schema-registry/src/error.rs
+++ b/crates/schema-registry/src/error.rs
@@ -1,8 +1,9 @@
-use crate::types::VersionedUuid;
 use semver::Version;
 use thiserror::Error;
 use tonic::Status;
 use uuid::Uuid;
+
+use crate::types::VersionedUuid;
 
 #[derive(Debug, Error)]
 pub enum RegistryError {

--- a/crates/schema-registry/src/main.rs
+++ b/crates/schema-registry/src/main.rs
@@ -1,12 +1,13 @@
+use std::fs::File;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::path::PathBuf;
+
 use anyhow::Context;
 use metrics_utils as metrics;
 use rpc::schema_registry::schema_registry_server::SchemaRegistryServer;
 use schema_registry::rpc::SchemaRegistryImpl;
 use schema_registry::settings::Settings;
 use settings_utils::load_settings;
-use std::fs::File;
-use std::net::{Ipv4Addr, SocketAddrV4};
-use std::path::PathBuf;
 use tokio::time::sleep;
 use tokio::time::Duration;
 use tonic::transport::Server;

--- a/crates/schema-registry/src/rpc.rs
+++ b/crates/schema-registry/src/rpc.rs
@@ -1,9 +1,7 @@
-use crate::db::SchemaRegistryDb;
-use crate::error::{RegistryError, RegistryResult};
-use crate::settings::Settings;
-use crate::types::schema::{NewSchema, SchemaDefinition, SchemaUpdate};
-use crate::types::view::{FullView, NewView, ViewUpdate};
-use crate::types::{DbExport, VersionedUuid};
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::pin::Pin;
+
 use bb8::Pool;
 use cdl_dto::materialization::Relation;
 use cdl_dto::{TryFromRpc, TryIntoRpc};
@@ -18,12 +16,16 @@ use rpc::schema_registry::{
 use semver::Version;
 use semver::VersionReq;
 use sqlx::types::Json;
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::pin::Pin;
 use tokio_stream::{Stream, StreamExt};
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
+
+use crate::db::SchemaRegistryDb;
+use crate::error::{RegistryError, RegistryResult};
+use crate::settings::Settings;
+use crate::types::schema::{NewSchema, SchemaDefinition, SchemaUpdate};
+use crate::types::view::{FullView, NewView, ViewUpdate};
+use crate::types::{DbExport, VersionedUuid};
 
 pub struct SchemaRegistryImpl {
     pub edge_registry: EdgeRegistryPool,

--- a/crates/schema-registry/src/settings.rs
+++ b/crates/schema-registry/src/settings.rs
@@ -1,7 +1,8 @@
+use std::path::PathBuf;
+
 use communication_utils::metadata_fetcher::MetadataFetcher;
 use serde::Deserialize;
 use settings_utils::*;
-use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {

--- a/crates/schema-registry/src/types/schema.rs
+++ b/crates/schema-registry/src/types/schema.rs
@@ -1,10 +1,10 @@
+use rpc::schema_registry::types::SchemaType;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
 use crate::types::view::View;
-use rpc::schema_registry::types::SchemaType;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Schema {

--- a/crates/schema-registry/src/utils.rs
+++ b/crates/schema-registry/src/utils.rs
@@ -1,8 +1,9 @@
-use crate::error::{RegistryError, RegistryResult};
-use crate::{db::SchemaRegistryDb, types::VersionedUuid};
 use jsonschema::JSONSchema;
 use serde_json::Value;
 use uuid::Uuid;
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::{db::SchemaRegistryDb, types::VersionedUuid};
 
 pub async fn build_full_schema(schema: &mut Value, conn: &SchemaRegistryDb) -> RegistryResult<()> {
     if let Some(defs) = schema

--- a/crates/utils/crates/cache/src/lib.rs
+++ b/crates/utils/crates/cache/src/lib.rs
@@ -1,7 +1,8 @@
-use lru::LruCache;
 use std::fmt;
 use std::future::Future;
 use std::hash::Hash;
+
+use lru::LruCache;
 use tokio::sync::Mutex;
 
 #[async_trait::async_trait]

--- a/crates/utils/crates/communication/src/consumer.rs
+++ b/crates/utils/crates/communication/src/consumer.rs
@@ -17,14 +17,11 @@ use tracing_futures::Instrument;
 
 #[cfg(feature = "kafka")]
 use super::kafka_ack_queue::KafkaAckQueue;
-
-#[cfg(feature = "kafka")]
-use crate::message::KafkaCommunicationMessage;
-
+use super::{message::CommunicationMessage, Result};
 #[cfg(feature = "amqp")]
 use crate::message::AmqpCommunicationMessage;
-
-use super::{message::CommunicationMessage, Result};
+#[cfg(feature = "kafka")]
+use crate::message::KafkaCommunicationMessage;
 
 #[async_trait]
 pub trait ConsumerHandler {

--- a/crates/utils/crates/communication/src/kafka_ack_queue.rs
+++ b/crates/utils/crates/communication/src/kafka_ack_queue.rs
@@ -4,14 +4,13 @@ use std::{
     sync::Mutex,
 };
 
+use misc_utils::abort_on_poison;
 use rdkafka::{
     consumer::{DefaultConsumerContext, StreamConsumer},
     message::BorrowedMessage,
     Message, Offset, TopicPartitionList,
 };
 use tracing::trace;
-
-use misc_utils::abort_on_poison;
 
 #[derive(Default)]
 pub struct KafkaAckQueue {

--- a/crates/utils/crates/communication/src/parallel_consumer.rs
+++ b/crates/utils/crates/communication/src/parallel_consumer.rs
@@ -1,4 +1,6 @@
 #![allow(unused_imports, unused_variables)]
+use std::{net::SocketAddrV4, sync::Arc};
+
 use anyhow::Context;
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
@@ -17,7 +19,6 @@ use rpc::generic as proto;
 use rpc::generic::generic_rpc_server::GenericRpc;
 #[cfg(feature = "grpc")]
 use rpc::generic::generic_rpc_server::GenericRpcServer;
-use std::{net::SocketAddrV4, sync::Arc};
 use task_utils::task_limiter::TaskLimiter;
 #[cfg(feature = "amqp")]
 use tokio_amqp::LapinTokioExt;

--- a/crates/utils/crates/communication/src/publisher.rs
+++ b/crates/utils/crates/communication/src/publisher.rs
@@ -1,4 +1,6 @@
 #![allow(unused_imports, unused_variables)]
+use std::time::Duration;
+
 #[cfg(feature = "amqp")]
 use lapin::{options::BasicPublishOptions, BasicProperties, Channel};
 #[cfg(feature = "kafka")]
@@ -9,7 +11,6 @@ use rdkafka::{
 };
 #[cfg(feature = "http")]
 use reqwest::Client;
-use std::time::Duration;
 #[cfg(feature = "amqp")]
 use tokio_amqp::LapinTokioExt;
 #[cfg(feature = "http")]

--- a/crates/utils/crates/misc/src/lib.rs
+++ b/crates/utils/crates/misc/src/lib.rs
@@ -78,9 +78,10 @@ pub mod serde_json {
 
     #[cfg(test)]
     mod tests {
-        use super::*;
         use serde_json::json;
         use test_case::test_case;
+
+        use super::*;
 
         #[test_case(json!({"b": 1, "c": 2, "a": 3,}), SortSettings::default() => r#"{"a":3,"b":1,"c":2}"# ; "simple")]
         #[test_case(json!([{"b": 1, "c": 2, "a": 3,}]), SortSettings::default() => r#"[{"a":3,"b":1,"c":2}]"# ; "in array")]

--- a/crates/utils/crates/settings/src/lib.rs
+++ b/crates/utils/crates/settings/src/lib.rs
@@ -1,3 +1,7 @@
+use std::env;
+use std::fmt::Debug;
+use std::net::SocketAddrV4;
+
 use anyhow::bail;
 use communication_utils::consumer::{CommonConsumer, CommonConsumerConfig};
 use communication_utils::parallel_consumer::{
@@ -8,9 +12,6 @@ use config::{Config, Environment, File};
 use derive_more::Display;
 use lapin::options::BasicConsumeOptions;
 use serde::{Deserialize, Serialize};
-use std::env;
-use std::fmt::Debug;
-use std::net::SocketAddrV4;
 use task_utils::task_limiter::TaskLimiter;
 use url::Url;
 

--- a/crates/utils/crates/task/src/task_limiter.rs
+++ b/crates/utils/crates/task/src/task_limiter.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::sync::Arc;
+
 use tokio::sync::Semaphore;
 
 #[derive(Clone)]

--- a/crates/utils/crates/tracing/src/http.rs
+++ b/crates/utils/crates/tracing/src/http.rs
@@ -1,9 +1,10 @@
+use std::convert::Infallible;
+
 use futures_util::TryFuture;
 use hyper::{Body, Request};
 use opentelemetry::global;
 use opentelemetry_http::{HeaderExtractor, HeaderInjector};
 use reqwest::RequestBuilder;
-use std::convert::Infallible;
 use tower_service::Service;
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;

--- a/crates/utils/src/notification/full_notification_sender.rs
+++ b/crates/utils/src/notification/full_notification_sender.rs
@@ -1,10 +1,12 @@
-use crate::notification::{IntoSerialize, NotificationService};
+use std::marker::PhantomData;
+use std::sync::Arc;
+
 use anyhow::Context;
 use communication_utils::publisher::CommonPublisher;
 use serde::Serialize;
-use std::marker::PhantomData;
-use std::sync::Arc;
 use tracing::{debug, trace};
+
+use crate::notification::{IntoSerialize, NotificationService};
 
 #[derive(Clone)]
 pub struct FullNotificationSenderBase<T, S>

--- a/crates/utils/src/notification/mod.rs
+++ b/crates/utils/src/notification/mod.rs
@@ -1,11 +1,13 @@
-use crate::notification::full_notification_sender::{
-    FullNotificationSender, FullNotificationSenderBase,
-};
+use std::future::Future;
+use std::marker::PhantomData;
+
 use cdl_dto::ingestion::OwnMessage;
 use communication_utils::publisher::CommonPublisher;
 use serde::{Deserialize, Serialize};
-use std::future::Future;
-use std::marker::PhantomData;
+
+use crate::notification::full_notification_sender::{
+    FullNotificationSender, FullNotificationSenderBase,
+};
 
 pub mod full_notification_sender;
 

--- a/crates/utils/src/parallel_task_queue.rs
+++ b/crates/utils/src/parallel_task_queue.rs
@@ -3,9 +3,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tokio::sync::oneshot::{channel, Receiver, Sender};
-
 use misc_utils::abort_on_poison;
+use tokio::sync::oneshot::{channel, Receiver, Sender};
 
 type LocksDB = Arc<Mutex<HashMap<String, LockQueue>>>;
 

--- a/crates/utils/src/psql.rs
+++ b/crates/utils/src/psql.rs
@@ -7,8 +7,9 @@ pub fn validate_schema(schema: &str) -> bool {
 #[cfg(test)]
 #[allow(clippy::bool_assert_comparison)]
 mod tests {
-    use super::*;
     use test_case::test_case;
+
+    use super::*;
 
     #[test_case("test" => true)]
     #[test_case("test;" => false)]

--- a/crates/utils/src/query_utils/error.rs
+++ b/crates/utils/src/query_utils/error.rs
@@ -1,5 +1,4 @@
 use thiserror::Error as DeriveError;
-
 pub use tonic::{Code, Status};
 
 #[derive(Debug, DeriveError)]

--- a/crates/utils/src/status_endpoints.rs
+++ b/crates/utils/src/status_endpoints.rs
@@ -1,9 +1,10 @@
+use std::convert::Infallible;
+use std::sync::RwLock;
+
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use lazy_static::lazy_static;
 use settings_utils::MonitoringSettings;
-use std::convert::Infallible;
-use std::sync::RwLock;
 use tracing::trace;
 
 lazy_static! {

--- a/e2e/src/on_demand_materializer/computed_fields.rs
+++ b/e2e/src/on_demand_materializer/computed_fields.rs
@@ -1,4 +1,7 @@
-use crate::{api::*, *};
+use std::collections::HashMap;
+use std::num::NonZeroU8;
+use std::time::Duration;
+
 use anyhow::Result;
 use cdl_api::types::view::NewRelation;
 use cdl_dto::materialization::{
@@ -6,11 +9,10 @@ use cdl_dto::materialization::{
 };
 use cdl_dto::materialization::{FieldDefinition, FieldType};
 use cdl_rpc::schema_registry::types::SearchFor;
-use std::collections::HashMap;
-use std::num::NonZeroU8;
-use std::time::Duration;
 use tokio::time::sleep;
 use uuid::Uuid;
+
+use crate::{api::*, *};
 
 #[tokio::test]
 #[ignore = "todo"]

--- a/e2e/src/on_demand_materializer/filtering.rs
+++ b/e2e/src/on_demand_materializer/filtering.rs
@@ -1,5 +1,8 @@
 mod on_standard_field {
-    use crate::{api::*, *};
+    use std::collections::HashMap;
+    use std::num::NonZeroU8;
+    use std::time::Duration;
+
     use anyhow::Result;
     use cdl_api::types::view::NewRelation;
     use cdl_dto::materialization::{
@@ -8,11 +11,10 @@ mod on_standard_field {
     };
     use cdl_dto::materialization::{ComputedFilter, FieldDefinition, FieldType, ViewPathFilter};
     use cdl_rpc::schema_registry::types::{LogicOperator, SearchFor};
-    use std::collections::HashMap;
-    use std::num::NonZeroU8;
-    use std::time::Duration;
     use tokio::time::sleep;
     use uuid::Uuid;
+
+    use crate::{api::*, *};
 
     #[tokio::test]
     #[ignore = "todo"]

--- a/e2e/src/on_demand_materializer/relations.rs
+++ b/e2e/src/on_demand_materializer/relations.rs
@@ -1,4 +1,7 @@
-use crate::{api::*, *};
+use std::collections::HashMap;
+use std::num::NonZeroU8;
+use std::time::Duration;
+
 use anyhow::Result;
 use cdl_api::types::view::NewRelation;
 use cdl_dto::materialization::{
@@ -7,11 +10,10 @@ use cdl_dto::materialization::{
 };
 use cdl_dto::materialization::{FieldDefinition, FieldType};
 use cdl_rpc::schema_registry::types::SearchFor;
-use std::collections::HashMap;
-use std::num::NonZeroU8;
-use std::time::Duration;
 use tokio::time::sleep;
 use uuid::Uuid;
+
+use crate::{api::*, *};
 
 #[tokio::test]
 async fn should_return_no_results_when_one_of_related_objects_does_not_exist() -> Result<()> {

--- a/e2e/src/on_demand_materializer/simple_views.rs
+++ b/e2e/src/on_demand_materializer/simple_views.rs
@@ -1,8 +1,10 @@
-use crate::{api::*, *};
-use anyhow::Result;
 use std::time::Duration;
+
+use anyhow::Result;
 use tokio::time::sleep;
 use uuid::Uuid;
+
+use crate::{api::*, *};
 
 #[tokio::test]
 async fn should_generate_empty_result_set_for_view_without_objects() -> Result<()> {

--- a/e2e/src/postgres_materializer.rs
+++ b/e2e/src/postgres_materializer.rs
@@ -1,4 +1,6 @@
-use crate::{api::*, *};
+use std::collections::HashMap;
+use std::time::Duration;
+
 use anyhow::Result;
 use bb8_postgres::{
     bb8::{Pool, PooledConnection},
@@ -7,10 +9,10 @@ use bb8_postgres::{
 };
 use cdl_dto::materialization::{FieldDefinition, FieldType, PostgresMaterializerOptions};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::time::Duration;
 use tokio::time::sleep;
 use uuid::Uuid;
+
+use crate::{api::*, *};
 
 const PG_SCHEMA: &str = "public";
 const PG_USER: &str = "postgres";

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use pico_args::Arguments;
-use std::path::PathBuf;
 
 mod codegen;
 


### PR DESCRIPTION
This is a proposal, not to be merged before other functionalities are dangling (reapplying rustfmt is easier than rebasing branches). We already do that in half of our files.